### PR TITLE
fix: shadeprops, motiontimefins and transt-on-positional not supporte…

### DIFF
--- a/docs/dss-configurator-ui-composition.md
+++ b/docs/dss-configurator-ui-composition.md
@@ -212,9 +212,9 @@ All 65 features defined in `src/model/modelconst.h` (enum class `ModelFeatureId`
 | 11 | `pushbarea` | Button | Push-button can be routed to area level |
 | 12 | `pushbadvanced` | Button | Advanced push-button configuration available |
 | 13 | `pushbcombined` | Button | Combined push-button modes (SDS20/22 2-button). **NOT supported for TCP/IP VDC** — `ButtonDescription/buttonType` is **read-only** in the VDC protocol and hardware-specific to physical TKM/SDS devices; the value does not align with the UI options. |
-| 14 | `shadeprops` | Shade | Shade/blind movement properties configurable |
+| 14 | `shadeprops` | Shade | Shade/blind movement properties configurable. **NOT supported for TCP/IP VDC** — writes motor timing via DS485 `setMaxMotionTime()`; VDC receives no write-back. |
 | 15 | `shadeposition` | Shade | Shade/blind position tracking supported |
-| 16 | `motiontimefins` | Shade | Venetian blind slat rotation time configurable |
+| 16 | `motiontimefins` | Shade | Venetian blind slat rotation time configurable. **NOT supported for TCP/IP VDC** — writes via DS485 `setMotionTime()`; VDC receives no write-back. |
 | 17 | `optypeconfig` | Output | Output type configurable (switch/dimmer selector) |
 | 18 | `shadebladeang` | Shade | Venetian blind blade angle configurable |
 | 19 | `highlevel` | Joker | Selection to configure App-Button within pushbutton |
@@ -475,9 +475,10 @@ pushbutton, pushbarea, pushbadvanced
 ```
 
 **Key Grey features for VDC shade device:**
-Roller blind: `dontcare, shadeprops, shadeposition, identification`
-Venetian blind: add `motiontimefins, shadebladeang`
+Roller blind: `dontcare, shadeposition, identification`
+Venetian blind: add `shadebladeang`
 With wind protection: add `locationconfig, windprotectionconfigblind` or `windprotectionconfigawning`
+(`shadeprops` and `motiontimefins` are **NOT supported** for TCP/IP VDC devices)
 
 ---
 
@@ -688,9 +689,9 @@ These enable various push-button configuration UI panels. Typically co-occur in 
 
 | Feature | ID | Meaning |
 |---|---|---|
-| `shadeprops` | 14 | Shade/blind movement properties (travel time, motor inertia) are configurable. |
+| `shadeprops` | 14 | Shade/blind movement properties (travel time, motor inertia) are configurable. **NOT supported for TCP/IP VDC** — DS485-only path, VDC receives no write-back. |
 | `shadeposition` | 15 | Shade/blind position can be tracked and reported. |
-| `motiontimefins` | 16 | Venetian blind fin/slat rotation time configurable (separate from main travel time). |
+| `motiontimefins` | 16 | Venetian blind fin/slat rotation time configurable (separate from main travel time). **NOT supported for TCP/IP VDC** — DS485-only path, VDC receives no write-back. |
 | `shadebladeang` | 18 | Venetian blind blade angle can be set and tracked. Enables angle control UI. |
 | `optypeconfig` | 17 | Output type (e.g., blind vs. awning) is user-configurable (Black devices). |
 | `locationconfig` | 36 | Shade installation location configurable (affects auto-sun-protection behavior). |
@@ -799,13 +800,15 @@ features = ["dontcare", "blink", "outvalue8", "transt", "outputchannels", "dimti
 ```python
 # Roller blind / awning (OutputFunction.POSITIONAL, no slat channel)
 # derive_model_features() produces:
-features = ["dontcare", "blink", "shadeprops", "shadeposition",
+features = ["dontcare", "blink", "shadeposition",
             "locationconfig", "operationlock", "windprotectionconfigawning", "identification"]
+# NOTE: shadeprops and motiontimefins are NOT supported for TCP/IP VDC devices.
 
 # Venetian blind (POSITIONAL + channelType 9 or 10)
-features = ["dontcare", "blink", "shadeprops", "shadeposition",
-            "motiontimefins", "shadebladeang",
+features = ["dontcare", "blink", "shadeposition",
+            "shadebladeang",
             "locationconfig", "operationlock", "windprotectionconfigblind", "identification"]
+# NOTE: shadeprops and motiontimefins are NOT supported for TCP/IP VDC devices.
 ```
 
 **Blue (primaryGroup=3) — Heating valve VDC device:**

--- a/docs/model-features-auto-assignment.md
+++ b/docs/model-features-auto-assignment.md
@@ -35,7 +35,7 @@ configured components.  All have a confirmed data path back to the vdSD.
 |---|---|---|
 | Any output present | `dontcare` | Per-scene "retain current value" checkbox |
 | Any output present | `blink` | Per-scene "blink effect" checkbox |
-| Channel type in {1–12, 14–18, 22–24} | `transt` | Per-scene transition-time radio button (standard / slow) |
+| Channel type in {1–12, 14–18, 22–24} **and** `function ≠ POSITIONAL` | `transt` | Per-scene transition-time radio button (standard / slow). Not derived for POSITIONAL outputs — those use hardware motor timing. |
 | `primaryGroup ≠ 2` (non-shade) | `outvalue8` | 8-bit "Edit Output Value" slider/input |
 | `function == ON_OFF` | `outconfigswitch` | Switch output threshold configuration UI |
 | `function == ON_OFF` | `impulseconfig` | "Impulse" tab in Device Properties for binary-output devices |
@@ -46,11 +46,17 @@ configured components.  All have a confirmed data path back to the vdSD.
 
 ### Grey / Shade Rules (primaryGroup == 2)
 
+> **`shadeprops` and `motiontimefins` are NOT supported for VDC devices.**
+> Both features open the "Device Properties Shade" panel which writes motor
+> travel/timing values via DS485 `setMaxMotionTime()` / `setMotionTime()`.
+> Those values are stored on the dSS side only — the VDC receives no
+> write-back and cannot react to the configuration.  Attempting to add either
+> feature with `add_model_feature()` raises `ValueError`.
+
 | Trigger | Features added | Configurator UI |
 |---|---|---|
-| `primaryGroup == 2` + any output | `shadeprops` | "Device Properties Shade" pop-up for positional timing |
 | `primaryGroup == 2` + `function == POSITIONAL` | `shadeposition` | 16-bit position slider/input and up/down/increment/decrement buttons |
-| POSITIONAL + channel type 9 or 10 (blade/slat) | `shadebladeang`, `motiontimefins` | Blade angle input/slider; blade motion timing in shade pop-up |
+| POSITIONAL + channel type 9 or 10 (blade/slat) | `shadebladeang` | Blade angle input/slider |
 | `primaryGroup == 2` + any output | `locationconfig` | Direction/orientation dropdown in Device Properties |
 | `primaryGroup == 2` + any output | `operationlock` | "Ignore operation lock for weather alarms" radio button (Advanced Settings) |
 | `primaryGroup == 2` + output + channel type 9 or 10 | `windprotectionconfigblind` | Wind protection class for jalousie/blind (stored on dSS) |
@@ -169,7 +175,7 @@ the dSS configurator.
 The following features are **rejected with `ValueError`** when passed to
 `add_model_feature()`. They will also never be auto-derived.
 
-Two root causes explain why they cannot work on TCP/IP VDC devices:
+Three root causes explain why they cannot work on TCP/IP VDC devices:
 
 **A — Output-mode selectors write via DS485, not via VDC:**  
 The configurator UI calls `setDeviceConfig(CfgClassFunction, CfgFunction_Mode, value)`
@@ -182,6 +188,12 @@ on it.
 These features control physical hardware capabilities (LED indicators, dimmer
 hardware type, TKM button hardware) that have no corresponding VDC property or
 API interaction.
+
+**C — Shade motion-timing configuration writes via DS485, not via VDC:**  
+The shade properties panel calls `setMaxMotionTime()` and `setMotionTime()` over
+the DS485 bus to store travel and slat-rotation times in the dSS device model.
+**No `setVdcProperty()` call is made.** The VDC neither receives the values nor
+can react to or store them.
 
 | Feature | Why not supported |
 |---|---|
@@ -204,6 +216,8 @@ API interaction.
 | `grkl387workaround` | **(B)** Hardware workaround for specific KL 0x387 firmware bug — injected by dSS firmware for physical KL devices; meaningless for VDC |
 | `akminput` | **(B)** "Input" dropdown to configure sensor behaviour (standard / inverted...) — hardware specific, no handlers / properties in vdc-API |
 | `akmdelay` | **(B)** "Turn-on / Turn-off delay" timings dropdowns for delayed sensor response — hardware specific, no handlers / properties in vdc-API |
+| `shadeprops` | **(C)** "Device Properties Shade" panel — writes motor travel time via DS485 `setMaxMotionTime()`; stored on dSS only, VDC receives no write-back |
+| `motiontimefins` | **(C)** Slat/fin rotation timing in the shade properties panel — writes via DS485 `setMotionTime()`; same DS485-only path as `shadeprops` |
 
 ---
 
@@ -247,9 +261,9 @@ output = Output(default_group=ColorClass.BLINDS, active_group=ColorClass.BLINDS,
 output.add_channel(OutputChannelType.SHADE_POSITION_OUTSIDE)
 output.add_channel(OutputChannelType.SHADE_OPENING_ANGLE_OUTSIDE)
 device.set_output(output)
-# Auto-derived: dontcare, blink, shadeprops, shadeposition, shadebladeang,
-#               motiontimefins, locationconfig, operationlock,
-#               windprotectionconfigblind
+# Auto-derived: dontcare, blink, shadeposition, shadebladeang,
+#               locationconfig, operationlock, windprotectionconfigblind
+# NOT derived:  shadeprops, motiontimefins (unsupported for TCP/IP VDC)
 ```
 
 ### Grey — Roller Shutter / Awning
@@ -260,8 +274,9 @@ output = Output(default_group=ColorClass.BLINDS, active_group=ColorClass.BLINDS,
                 groups={ColorClass.BLINDS}, function=OutputFunction.POSITIONAL)
 output.add_channel(OutputChannelType.SHADE_POSITION_OUTSIDE)
 device.set_output(output)
-# Auto-derived: dontcare, blink, shadeprops, shadeposition, locationconfig,
+# Auto-derived: dontcare, blink, shadeposition, locationconfig,
 #               operationlock, windprotectionconfigawning
+# NOT derived:  shadeprops (unsupported for TCP/IP VDC)
 ```
 
 ### Blue — Heating Valve (ON/OFF)

--- a/docs/vdc-api-properties.md
+++ b/docs/vdc-api-properties.md
@@ -229,19 +229,24 @@ Requires `primaryGroup=8` (Black) for `jokerconfig` and `jokertempcontrol` to ta
 
 ##### E — Shade / Blind Properties Panel (Grey / GR Group)
 
-Requires `primaryGroup=2` (GREY). `shadeprops` is the master gate.
+Requires `primaryGroup=2` (GREY).
+
+> **`shadeprops` and `motiontimefins` are NOT supported for TCP/IP VDC devices.**
+> Both write motor timing via DS485 `setMaxMotionTime()` / `setMotionTime()`;
+> the dSS stores the values internally without forwarding them to the VDC.
+> `add_model_feature()` raises `ValueError` for both.
 
 | ID | Feature | Effect | dSS API | Notes | Derivation |
 |---|---|---|---|---|---|
-| 14 | `shadeprops` | **Master gate.** Enables shade properties panel. | Shade properties tab | Required for all other shade features | `auto: primaryGroup=2 (GREY / outdoor shade)` |
-| 15 | `shadeposition` | Enables shade position control (0–100%) per scene. | Scene editor position field | Requires `shadeprops` | `auto: shade output + outputFunction=POSITIONAL` |
-| 18 | `shadebladeang` | Enables slat/blade angle control (0–100°) for venetian blinds. | Scene editor angle field | Requires `shadeprops`; jalousie hardware only | `auto: shade output + channelType 9 or 10 present` |
-| 16 | `motiontimefins` | Enables travel time calibration for slat movement. | `setMaxMotionTime()` / `setMotionTime()` | Requires `shadeprops`; jalousie/venetian blind only | `auto: shade output + channelType 9 or 10 present` |
+| 14 | `shadeprops` | **NOT SUPPORTED.** Would enable shade properties panel. | `setMaxMotionTime()` | DS485-only path; VDC receives no write-back | `not-supported-vdc` |
+| 15 | `shadeposition` | Enables shade position control (0–100%) per scene. | Scene editor position field | — | `auto: shade output + outputFunction=POSITIONAL` |
+| 18 | `shadebladeang` | Enables slat/blade angle control (0–100°) for venetian blinds. | Scene editor angle field | Jalousie hardware only | `auto: shade output + channelType 9 or 10 present` |
+| 16 | `motiontimefins` | **NOT SUPPORTED.** Would enable fin/slat rotation time calibration. | `setMotionTime()` | DS485-only path; VDC receives no write-back | `not-supported-vdc` |
 | 17 | `optypeconfig` | Output type selector (Switched / Swiped / PowerSafe). Selection changes dSS `m_OutputMode` via DS485 `CfgFunction_Mode` — these mode IDs have no VDC equivalent. **NOT supported for TCP/IP VDC.** | Output type selector | — | `not-supported-vdc` |
 
 ##### F — Location & Wind Protection (GR Group)
 
-Requires `primaryGroup=2` and `shadeprops`.
+Requires `primaryGroup=2`.
 
 | ID | Feature | Effect | dSS API | Notes | Derivation |
 |---|---|---|---|---|---|
@@ -324,8 +329,8 @@ All features in the "Auto-derived features" column are produced automatically by
 | Dimmable light (DIMMER function) | `dontcare`, `blink`, `outvalue8`, `transt`, `dimtimeconfig` | — |
 | Switched light (ON_OFF function) | `dontcare`, `blink`, `outvalue8`, `transt`, `outconfigswitch`, `impulseconfig` | — |
 | Color light (FULL_COLOR_DIMMER) | `dontcare`, `blink`, `outvalue8`, `transt`, `outputchannels`, `dimtimeconfig` | — |
-| Roller shutter / awning | `dontcare`, `blink`, `shadeprops`, `shadeposition`, `transt`, `locationconfig`, `operationlock`, `windprotectionconfigawning` | — |
-| Venetian blind / jalousie | `dontcare`, `blink`, `shadeprops`, `shadeposition`, `shadebladeang`, `motiontimefins`, `transt`, `locationconfig`, `operationlock`, `windprotectionconfigblind` | — |
+| Roller shutter / awning | `dontcare`, `blink`, `shadeposition`, `locationconfig`, `operationlock`, `windprotectionconfigawning` | `shadeprops`, `motiontimefins` not supported |
+| Venetian blind / jalousie | `dontcare`, `blink`, `shadeposition`, `shadebladeang`, `locationconfig`, `operationlock`, `windprotectionconfigblind` | `shadeprops`, `motiontimefins` not supported |
 | Heating valve (ON/OFF) | `dontcare`, `blink`, `outvalue8`, `transt`, `pwmvalue`, `outconfigswitch`, `impulseconfig`, `heatinggroup`, `heatingprops`, `valvetype`, `extendedvalvetypes` | — |
 | Heating valve (continuous/PWM) | `dontcare`, `blink`, `outvalue8`, `transt`, `dimtimeconfig`, `pwmvalue`, `heatinggroup`, `heatingprops`, `valvetype`, `extendedvalvetypes` | — |
 | Joker with group assignment | `jokerconfig` (pg=8), `highlevel` (when button with group=8 present) | — |

--- a/docs/vdc-host-behavior.md
+++ b/docs/vdc-host-behavior.md
@@ -552,7 +552,8 @@ the device is announced.  Key auto-derivation rules:
 - Any output → `dontcare`, `blink`
 - ON_OFF function → `outconfigswitch`, `impulseconfig`
 - DIMMER / DIMMER_COLOR_TEMP / FULL_COLOR_DIMMER function → `dimtimeconfig`
-- Grey shade output with slat channel → `shadebladeang`, `motiontimefins`
+- Grey shade output with slat channel → `shadebladeang`
+  (`shadeprops` and `motiontimefins` are NOT supported for TCP/IP VDC — DS485-only path)
 - Any binary input → `akmsensor` (`akminput` and `akmdelay` are not supported for VDC devices)
 - Any button → `pushbutton`, `pushbadvanced`, `pushbdisabled`
 

--- a/examples/developer_guide_demo.py
+++ b/examples/developer_guide_demo.py
@@ -473,8 +473,9 @@ def build_device_3(vdc: Vdc) -> Device:
       ``output.add_channel()`` (not auto-created)
 
     **Derived model features:**
-    ``dontcare``, ``shade``, ``transt``, ``shadeprops``,
-    ``shadeposition``, ``locationconfig``, ``windprotectionconfig``
+    ``dontcare``, ``blink``, ``shadeposition``, ``locationconfig``,
+    ``windprotectionconfigawning``
+    (``shadeprops`` is NOT supported for TCP/IP VDC devices)
 
     Note: ``BinaryInputType.GARAGE_DOOR_OPEN`` (16) is not in the
     ``presence`` set {1,3,5,6} nor the ``window`` set {13,14,15},

--- a/examples/full_showcase.py
+++ b/examples/full_showcase.py
@@ -615,7 +615,6 @@ def build_d09_blinds_positional(vdc: Vdc, idx: int) -> DevInfo:
     out.add_channel(OutputChannelType.SHADE_OPENING_ANGLE_OUTSIDE)
     out.on_channel_applied = _channel_callback(name)
 
-    v.add_model_feature("shadeprops")
     v.add_model_feature("shadeposition")
     v.add_model_feature("shadebladeang")
     v.add_model_feature("ledauto")
@@ -636,7 +635,6 @@ def build_d10_awnings(vdc: Vdc, idx: int) -> DevInfo:
     out.add_channel(OutputChannelType.SHADE_POSITION_OUTSIDE)
     out.on_channel_applied = _channel_callback(name)
 
-    v.add_model_feature("shadeprops")
     v.add_model_feature("shadeposition")
     v.add_model_feature("locationconfig")  # orientation dropdown
     v.add_model_feature(
@@ -831,7 +829,6 @@ def build_d19_motorised_window(vdc: Vdc, idx: int) -> DevInfo:
     out.add_channel(OutputChannelType.SHADE_POSITION_OUTSIDE)
     out.on_channel_applied = _channel_callback(name)
 
-    v.add_model_feature("shadeprops")
     v.add_model_feature("shadeposition")
     v.add_model_feature("ledauto")
     v.derive_model_features()

--- a/src/pydsvdcapi/vdsd.py
+++ b/src/pydsvdcapi/vdsd.py
@@ -624,7 +624,7 @@ class Vdsd:
     _VENTILATION_CHANNEL_TYPES: frozenset = frozenset({12, 13, 14, 15, 20, 21})
 
     # Features that cannot be used with TCP/IP VDC devices and must never be
-    # declared.  Three root causes:
+    # declared.  Four root causes:
     #   1. Output-mode selectors (outmode, outmodeswitch, …) write to the dSS
     #      m_OutputMode field via DS485 CfgFunction_Mode.  The written value is
     #      never forwarded to the VDC, so VDC devices cannot observe or react
@@ -634,6 +634,9 @@ class Vdsd:
     #   3. AKM input configuration (akminput, akmdelay) writes to DS485 bus
     #      registers via setAKMInputProperty() / setAKMInputTimeouts(); the
     #      written values are never forwarded to the VDC.
+    #   4. Shade properties configuration (shadeprops, motiontimefins) triggers
+    #      setMaxMotionTime() / setMotionTime() DS485 calls whose results are
+    #      stored on the dSS side only; the VDC receives no write-back.
     _UNSUPPORTED_MODEL_FEATURES: frozenset = frozenset(
         {
             # LED indicators — not API-controlled on VDC devices
@@ -662,6 +665,11 @@ class Vdsd:
             # AKM input/delay config — DS485 bus only, never reaches VDC
             "akminput",
             "akmdelay",
+            # Shade properties / motion timing — triggers setMaxMotionTime() /
+            # setMotionTime() DS485 calls; values stored on dSS only, VDC
+            # receives no write-back and cannot react to the configuration.
+            "shadeprops",
+            "motiontimefins",
         }
     )
 
@@ -693,12 +701,15 @@ class Vdsd:
         **Output / channel rules**
 
         * Any output present → ``"dontcare"``, ``"blink"``
-        * Any channel with ``channelType`` in 1–12, 14–18, or 22–24 →
-          ``"transt"``
-        * ``primaryGroup`` 2 (GREY / outdoor shade) → ``"shadeprops"``
-        * ``primaryGroup`` 2 + ``function`` POSITIONAL (2) →
-          ``"shadeposition"``; additionally ``channelType`` 9 or 10
-          present → ``"shadebladeang"`` + ``"motiontimefins"``
+        * Any channel with ``channelType`` in 1–12, 14–18, or 22–24
+          AND ``function`` ≠ POSITIONAL(2) → ``"transt"``
+          (positional outputs use hardware motor timing, not transition
+          time, so ``"transt"`` is never derived for them)
+        * ``primaryGroup`` 2 (GREY / outdoor shade) + ``function``
+          POSITIONAL (2) → ``"shadeposition"``; additionally
+          ``channelType`` 9 or 10 present → ``"shadebladeang"``
+          (``"shadeprops"`` and ``"motiontimefins"`` are **not**
+          auto-derived — they are unsupported for TCP/IP VDC devices)
         * ``primaryGroup`` ≠ 2 → ``"outvalue8"``
         * Both ``channelType`` 2 (HUE) and 3 (SATURATION) present, or
           both 1 (BRIGHTNESS) and 4 (COLOR_TEMPERATURE) present →
@@ -754,10 +765,11 @@ class Vdsd:
 
         Note: features in :attr:`_UNSUPPORTED_MODEL_FEATURES` are
         **never** auto-derived and will raise :exc:`ValueError` if
-        passed to :meth:`add_model_feature`.  These are features whose
-        configuration is written to the dSS hardware register via DS485
-        and never forwarded to VDC devices, or features tied to physical
-        hardware capabilities with no VDC write-back path.  See
+        passed to :meth:`add_model_feature`.  This includes
+        ``"shadeprops"`` and ``"motiontimefins"`` — the shade properties
+        panel writes motor timing via DS485 ``setMaxMotionTime()`` /
+        ``setMotionTime()``; the VDC receives no write-back and cannot
+        react to those settings.  See
         ``docs/model-features-auto-assignment.md`` for the full list and
         rationale.
         """
@@ -774,18 +786,20 @@ class Vdsd:
             ch_types = {int(ch.channel_type) for ch in self._output.channels.values()}
             has_blade_channel = bool(ch_types & {9, 10})
 
-            # transt: channels with smooth transition support
-            if ch_types & self._TRANST_CHANNEL_TYPES:
+            # transt: smooth transition support — not for POSITIONAL outputs,
+            # which use hardware motor timing rather than software transition time.
+            if fn != 2 and ch_types & self._TRANST_CHANNEL_TYPES:
                 self._model_features.add("transt")
 
             # shade vs. normal output — determined by primaryGroup (ColorGroup.GREY=2)
+            # "shadeprops" and "motiontimefins" are NOT derived: they open the
+            # shade-properties panel which writes motor timing via DS485
+            # setMaxMotionTime()/setMotionTime(); the VDC receives no write-back.
             if pg == 2:  # ColorGroup.GREY — outdoor shade device
-                self._model_features.add("shadeprops")
                 if fn == 2:  # OutputFunction.POSITIONAL
                     self._model_features.add("shadeposition")
                     if has_blade_channel:
                         self._model_features.add("shadebladeang")
-                        self._model_features.add("motiontimefins")
             else:
                 self._model_features.add("outvalue8")
 

--- a/tests/test_vdsd.py
+++ b/tests/test_vdsd.py
@@ -296,15 +296,15 @@ class TestVdsdGetProperties:
             device,
             primary_group=ColorGroup.GREY,
             zone_id=42,
-            model_features={"shadeprops", "shadeposition"},
+            model_features={"blink", "shadeposition"},
         )
 
         props = vdsd.get_properties()
         assert props["primaryGroup"] == int(ColorGroup.GREY)
         assert props["zoneID"] == 42
         assert props["modelFeatures"] == {
+            "blink": True,
             "shadeposition": True,
-            "shadeprops": True,
         }
 
     def test_empty_model_features(self):
@@ -367,14 +367,14 @@ class TestVdsdApplyState:
             "name": "Restored Name",
             "zoneID": 99,
             "primaryGroup": int(ColorGroup.GREY),
-            "modelFeatures": ["blink", "shadeprops"],
+            "modelFeatures": ["blink", "shadeposition"],
         }
         vdsd._apply_state(state)
 
         assert vdsd.name == "Restored Name"
         assert vdsd.zone_id == 99
         assert vdsd.primary_group == ColorGroup.GREY
-        assert vdsd.model_features == {"blink", "shadeprops"}
+        assert vdsd.model_features == {"blink", "shadeposition"}
 
     def test_restore_dsuid(self):
         host = _make_host()
@@ -1600,6 +1600,22 @@ class TestDeriveModelFeatures:
         vdsd.derive_model_features()
         assert "transt" not in vdsd.model_features
 
+    def test_no_transt_for_positional_output(self):
+        # POSITIONAL outputs use hardware motor timing, not software transition time.
+        vdsd, _ = self._setup(primary_group=ColorGroup.GREY)
+        output = Output(
+            vdsd=vdsd,
+            function=OutputFunction.POSITIONAL,
+            name="output",
+            default_group=16,
+            active_group=16,
+            groups={16},
+        )
+        output.add_channel(OutputChannelType.SHADE_POSITION_OUTSIDE)
+        vdsd.set_output(output)
+        vdsd.derive_model_features()
+        assert "transt" not in vdsd.model_features
+
     # ---- button rules ----------------------------------------------------
 
     def test_button_basic_features(self):
@@ -1687,7 +1703,7 @@ class TestDeriveModelFeatures:
 
     # ---- shade / outvalue8 rules ----------------------------------------
 
-    def test_shade_primarygroup_grey_adds_shadeprops(self):
+    def test_shade_primarygroup_grey_no_shadeprops(self):
         vdsd, _ = self._setup(primary_group=ColorGroup.GREY)
         vdsd.set_output(
             Output(
@@ -1700,7 +1716,7 @@ class TestDeriveModelFeatures:
             )
         )
         vdsd.derive_model_features()
-        assert "shadeprops" in vdsd.model_features
+        assert "shadeprops" not in vdsd.model_features
 
     def test_shade_primarygroup_grey_function_positional_adds_shadeposition(self):
         vdsd, _ = self._setup(primary_group=ColorGroup.GREY)
@@ -1732,7 +1748,7 @@ class TestDeriveModelFeatures:
         vdsd.set_output(output)
         vdsd.derive_model_features()
         assert "shadebladeang" in vdsd.model_features
-        assert "motiontimefins" in vdsd.model_features
+        assert "motiontimefins" not in vdsd.model_features
 
     def test_shade_position_without_blade_channels_no_shadebladeang(self):
         vdsd, _ = self._setup(primary_group=ColorGroup.GREY)
@@ -1748,7 +1764,9 @@ class TestDeriveModelFeatures:
         )
         vdsd.derive_model_features()
         assert "shadebladeang" not in vdsd.model_features
-        assert "motiontimefins" not in vdsd.model_features
+        assert (
+            "motiontimefins" not in vdsd.model_features
+        )  # never derived — unsupported
 
     def test_non_shade_output_adds_outvalue8(self):
         vdsd, _ = self._setup()
@@ -2432,6 +2450,16 @@ class TestDeriveModelFeatures:
         vdsd, _ = self._setup()
         with pytest.raises(ValueError, match="consumptioneventled"):
             vdsd.add_model_feature("consumptioneventled")
+
+    def test_add_unsupported_shadeprops_raises(self):
+        vdsd, _ = self._setup()
+        with pytest.raises(ValueError, match="shadeprops"):
+            vdsd.add_model_feature("shadeprops")
+
+    def test_add_unsupported_motiontimefins_raises(self):
+        vdsd, _ = self._setup()
+        with pytest.raises(ValueError, match="motiontimefins"):
+            vdsd.add_model_feature("motiontimefins")
 
     def test_add_supported_blink_does_not_raise(self):
         # Verify that a legitimate optional feature can still be added manually


### PR DESCRIPTION
…d for TCP/IP VDC

- Add shadeprops and motiontimefins to _UNSUPPORTED_MODEL_FEATURES: both open the shade-properties panel which writes motor timing via DS485 setMaxMotionTime()/setMotionTime(); the VDC receives no write-back.
- Remove auto-derivation of shadeprops and motiontimefins from derive_model_features().
- Do not derive transt for OutputFunction.POSITIONAL outputs: positional devices use hardware motor timing, not software transition time.
- Remove add_model_feature("shadeprops") calls from full_showcase.py (D09 blinds, D10 awnings, D19 window opener).
- Update all docs (model-features-auto-assignment.md, dss-configurator-ui-composition.md, vdc-api-properties.md, vdc-host-behavior.md) and inline comments.
- Add tests: shadeprops/motiontimefins raise ValueError; transt not derived for positional output; shadeprops not in grey device features.