### PR TITLE
fix: grey device protocol compatibility (v0.8.8)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -209,6 +209,9 @@ __marimo__/
 # Documentation folder
 Documentation/
 
+# Local research / comparison documents (not for version control)
+docs/p44vdc-comparison.md
+
 # Examples pycache
 examples/__pycache__/
 .claude/settings.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `ChannelSpec` now carries `siunit` and `symbol` fields; all built-in channel specs are populated with the appropriate SI unit and symbol (e.g. `percent`/`%` for brightness/shade, `degree`/`°` for hue, `reciprocal megakelvin`/`mired` for color temperature). These are emitted in `channelDescriptions` responses to match the p44vdc wire format and fix grey-device validation errors on dSS.
 - Shadow motor timing fields `openTime`, `closeTime`, `angleOpenTime`, `angleCloseTime`, `stopDelayTime` added to `outputSettings` for shade devices. dSS reads and writes these to configure motor travel timing.
 - `transitionTime` field (float, seconds) added to `outputState`, matching p44vdc's `outputStateProperties`.
+- `movingState` (integer) added to `outputState` for shade/blind outputs: `0` = idle, `1` = moving open/up, `-1` = moving closed/down. Matches p44vdc `ShadowBehaviour` wire format.
 - Unknown `setProperty outputSettings` keys are now stored in `Output._extra_settings` and returned in future `get_settings_properties()` responses instead of being silently dropped.
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.8] - 2026-05-30
+
+### Added
+- `ChannelSpec` now carries `siunit` and `symbol` fields; all built-in channel specs are populated with the appropriate SI unit and symbol (e.g. `percent`/`%` for brightness/shade, `degree`/`°` for hue, `reciprocal megakelvin`/`mired` for color temperature). These are emitted in `channelDescriptions` responses to match the p44vdc wire format and fix grey-device validation errors on dSS.
+- Shadow motor timing fields `openTime`, `closeTime`, `angleOpenTime`, `angleCloseTime`, `stopDelayTime` added to `outputSettings` for shade devices. dSS reads and writes these to configure motor travel timing.
+- `transitionTime` field (float, seconds) added to `outputState`, matching p44vdc's `outputStateProperties`.
+- Unknown `setProperty outputSettings` keys are now stored in `Output._extra_settings` and returned in future `get_settings_properties()` responses instead of being silently dropped.
+
+### Fixed
+- Shade channel resolution corrected from 8-bit (`100/255 ≈ 0.392`) to 16-bit (`100/65536 ≈ 0.00153`), matching p44vdc's precision. Affects `SHADE_POSITION_OUTSIDE`, `SHADE_POSITION_INDOOR`, `SHADE_OPENING_ANGLE_OUTSIDE`, `SHADE_OPENING_ANGLE_INDOOR`.
+- All channel container keys (`channelDescriptions`, `channelSettings`, `channelStates` in GET responses and push notifications) now use the channel's **dsIndex** as string key (e.g. `"0"`, `"1"`), matching the p44vdc wire format. The 0.8.6 change that switched to channel name keys is reverted; name-based lookup in `vdc_host.py` for incoming `setOutputChannelValue` notifications is unchanged.
+
 ## [0.8.7] - 2026-05-22
 
 ### Fixed
@@ -102,6 +114,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `DsUid` — dSUID encoding/decoding with multiple creation strategies.
 - Property handling helpers (`build_get_property_response`, etc.).
 
+[0.8.8]: https://github.com/KarlKiel/pyDSvDCAPI/compare/v0.8.7...v0.8.8
+[0.8.7]: https://github.com/KarlKiel/pyDSvDCAPI/compare/v0.8.6...v0.8.7
 [0.8.6]: https://github.com/KarlKiel/pyDSvDCAPI/compare/v0.8.4...v0.8.6
 [0.8.4]: https://github.com/KarlKiel/pyDSvDCAPI/compare/v0.8.3...v0.8.4
 [0.8.3]: https://github.com/KarlKiel/pyDSvDCAPI/compare/v0.8.1...v0.8.3

--- a/docs/superpowers/plans/2026-05-30-grey-device-protocol-fixes.md
+++ b/docs/superpowers/plans/2026-05-30-grey-device-protocol-fixes.md
@@ -1,0 +1,740 @@
+# Grey Device Protocol Compatibility — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix five wire-format discrepancies between pydsvdcapi and p44vdc that cause errors on grey (shade/blind) devices, add shadow-specific `outputSettings` timing fields, and ensure unknown `setProperty` keys are stored and returned instead of silently dropped.
+
+**Architecture:** All changes are additive or corrective field changes in `output_channel.py`, `output.py`, and `vdc_host.py`. No new classes or files needed. Each task is self-contained and can be tested independently.
+
+**Tech Stack:** Python 3.10+, pytest, protobuf (vdcapi), pydsvdcapi internal library.
+
+**Branch:** `fix-grey-device-protocol-0.8.8`
+
+**Reference:** Analysis document at `docs/p44vdc-comparison.md` (git-ignored, local only).
+
+---
+
+## Change Notes for This Branch
+
+### What is being fixed and why
+
+**CRITICAL-1 — `siunit` and `symbol` missing from `channelDescriptions`**
+p44vdc sends `siunit` (e.g. `"percent"`) and `symbol` (e.g. `"%"`) in every channel description element. pydsvdcapi omits both. The dSS firmware uses `siunit` for channel value validation and unit display. Their absence is identified as the most likely root cause of grey-device errors.
+
+**CRITICAL-2 — Shade channel resolution 250× too coarse**
+p44vdc uses `100/65536 ≈ 0.001526` (16-bit precision) for shade position and angle channels. pydsvdcapi uses `100/255 ≈ 0.392` (8-bit). This was identified in the p44vdc analysis and matches the reference implementation.
+
+**CRITICAL-3 — Channel container keys use channel name instead of dsIndex**
+p44vdc keys all channel containers (`channelDescriptions`, `channelSettings`, `channelStates` in both GET responses and push notifications) by integer dsIndex as string (e.g. `"0"`). pydsvdcapi 0.8.6 switched to channel name keys everywhere. This change reverts the key format back to dsIndex for all four locations — GET responses and push notifications — to match p44vdc exactly. The `setOutputChannelValue` and `setProperty channelStates` handlers in `vdc_host.py` (which look up channels by name from the notification payload) are unchanged.
+
+**WARN-4 — Shadow-specific `outputSettings` fields missing**
+p44vdc's `ShadowBehaviour` adds `openTime`, `closeTime`, `angleOpenTime`, `angleCloseTime`, `stopDelayTime` (all double, seconds) to `outputSettings` for grey devices. dSS reads and writes these to configure motor timing. pydsvdcapi silently ignores them.
+
+**WARN-5 — `transitionTime` missing from `outputState`**
+p44vdc includes `transitionTime` (double, seconds) in `outputState`. dSS may use this to track whether a transition is in progress. pydsvdcapi omits it.
+
+**NEW — Unknown `setProperty` keys stored instead of silently dropped**
+Currently `Output.apply_settings()` says "Unknown keys are silently ignored." If dSS writes a setting the library doesn't recognise, it disappears. After this change, any unrecognised key is stored in `Output._extra_settings` and returned in future `get_settings_properties()` responses.
+
+---
+
+## File Map
+
+| File | Changes |
+|---|---|
+| `src/pydsvdcapi/output_channel.py` | Add `siunit`/`symbol` to `ChannelSpec`; populate all channel specs; expose in `get_description_properties()`; fix shade resolutions |
+| `src/pydsvdcapi/output.py` | All channel container keys → dsIndex (GET responses + push); add shadow timing fields; add `transitionTime`; add `_extra_settings` |
+| `tests/test_output_channel.py` | Assert `siunit`/`symbol` present; assert correct shade resolution |
+| `tests/test_output.py` | Assert push uses dsIndex key; assert shadow fields round-trip; assert `transitionTime` present; assert extra settings persist |
+
+---
+
+## Task 1: Add `siunit` and `symbol` to `ChannelSpec` and all channel specs
+
+**Files:**
+- Modify: `src/pydsvdcapi/output_channel.py`
+- Test: `tests/test_output_channel.py`
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# In TestChannelSpec / TestOutputChannel (test_output_channel.py)
+
+def test_channel_description_includes_siunit_and_symbol():
+    ch = OutputChannel(channel_type=OutputChannelType.BRIGHTNESS, ds_index=0, output=...)
+    desc = ch.get_description_properties()
+    assert "siunit" in desc
+    assert "symbol" in desc
+    assert desc["siunit"] == "percent"
+    assert desc["symbol"] == "%"
+
+def test_shade_channel_description_includes_siunit_percent():
+    ch = OutputChannel(
+        channel_type=OutputChannelType.SHADE_POSITION_OUTSIDE, ds_index=0, output=...
+    )
+    desc = ch.get_description_properties()
+    assert desc["siunit"] == "percent"
+    assert desc["symbol"] == "%"
+
+def test_colortemp_channel_siunit():
+    ch = OutputChannel(
+        channel_type=OutputChannelType.COLOR_TEMPERATURE, ds_index=1, output=...
+    )
+    desc = ch.get_description_properties()
+    assert desc["siunit"] == "reciprocal megakelvin"
+    assert desc["symbol"] == "mired"
+
+def test_hue_channel_siunit():
+    ch = OutputChannel(
+        channel_type=OutputChannelType.HUE, ds_index=1, output=...
+    )
+    desc = ch.get_description_properties()
+    assert desc["siunit"] == "degree"
+    assert desc["symbol"] == "°"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pytest tests/test_output_channel.py -k "siunit or symbol" -v
+```
+Expected: FAIL — `KeyError: 'siunit'`
+
+- [ ] **Step 3: Add `siunit` and `symbol` to `ChannelSpec` dataclass**
+
+In `output_channel.py`, extend the `ChannelSpec` dataclass:
+
+```python
+@dataclass(frozen=True)
+class ChannelSpec:
+    name: str
+    min_value: float
+    max_value: float
+    resolution: float
+    siunit: str = ""
+    symbol: str = ""
+```
+
+- [ ] **Step 4: Populate `siunit`/`symbol` in `CHANNEL_SPECS`**
+
+Update every entry in `CHANNEL_SPECS`. Full values (derived from p44vdc channel constructors):
+
+```python
+CHANNEL_SPECS: dict[OutputChannelType, ChannelSpec] = {
+    OutputChannelType.BRIGHTNESS: ChannelSpec(
+        name="brightness", min_value=0, max_value=100, resolution=100/255,
+        siunit="percent", symbol="%",
+    ),
+    OutputChannelType.HUE: ChannelSpec(
+        name="hue", min_value=0, max_value=360, resolution=360/255,
+        siunit="degree", symbol="°",
+    ),
+    OutputChannelType.SATURATION: ChannelSpec(
+        name="saturation", min_value=0, max_value=100, resolution=100/255,
+        siunit="percent", symbol="%",
+    ),
+    OutputChannelType.COLOR_TEMPERATURE: ChannelSpec(
+        name="colortemp", min_value=100, max_value=1000, resolution=900/255,
+        siunit="reciprocal megakelvin", symbol="mired",
+    ),
+    OutputChannelType.CIE_X: ChannelSpec(
+        name="x", min_value=0, max_value=10000, resolution=10000/255,
+        siunit="", symbol="",
+    ),
+    OutputChannelType.CIE_Y: ChannelSpec(
+        name="y", min_value=0, max_value=10000, resolution=10000/255,
+        siunit="", symbol="",
+    ),
+    # -- Shade channels (resolution matches p44vdc 16-bit precision) ------
+    OutputChannelType.SHADE_POSITION_OUTSIDE: ChannelSpec(
+        name="shadePositionOutside", min_value=0, max_value=100, resolution=100/65536,
+        siunit="percent", symbol="%",
+    ),
+    OutputChannelType.SHADE_POSITION_INDOOR: ChannelSpec(
+        name="shadePositionIndoor", min_value=0, max_value=100, resolution=100/65536,
+        siunit="percent", symbol="%",
+    ),
+    OutputChannelType.SHADE_OPENING_ANGLE_OUTSIDE: ChannelSpec(
+        name="shadeOpeningAngleOutside", min_value=0, max_value=100, resolution=100/65536,
+        siunit="percent", symbol="%",
+    ),
+    OutputChannelType.SHADE_OPENING_ANGLE_INDOOR: ChannelSpec(
+        name="shadeOpeningAngleIndoor", min_value=0, max_value=100, resolution=100/65536,
+        siunit="percent", symbol="%",
+    ),
+    OutputChannelType.TRANSPARENCY: ChannelSpec(
+        name="transparency", min_value=0, max_value=100, resolution=100/255,
+        siunit="percent", symbol="%",
+    ),
+    # -- Climate channels -------------------------------------------------
+    OutputChannelType.HEATING_POWER: ChannelSpec(
+        name="heatingPower", min_value=0, max_value=100, resolution=100/255,
+        siunit="percent", symbol="%",
+    ),
+    OutputChannelType.COOLING_CAPACITY: ChannelSpec(
+        name="coolingCapacity", min_value=0, max_value=100, resolution=100/255,
+        siunit="percent", symbol="%",
+    ),
+    # -- Ventilation channels ---------------------------------------------
+    OutputChannelType.AIR_FLOW_INTENSITY: ChannelSpec(
+        name="airFlowIntensity", min_value=0, max_value=100, resolution=100/255,
+        siunit="percent", symbol="%",
+    ),
+    OutputChannelType.AIR_FLOW_DIRECTION: ChannelSpec(
+        name="airFlowDirection", min_value=0, max_value=2, resolution=1,
+        siunit="", symbol="",
+    ),
+    OutputChannelType.AIR_LOUVER_POSITION: ChannelSpec(
+        name="airLouverPosition", min_value=0, max_value=100, resolution=100/255,
+        siunit="percent", symbol="%",
+    ),
+    OutputChannelType.AIR_LOUVER_AUTO: ChannelSpec(
+        name="airLouverAuto", min_value=0, max_value=1, resolution=1,
+        siunit="", symbol="",
+    ),
+    OutputChannelType.AIR_FLOW_AUTO: ChannelSpec(
+        name="airFlowAuto", min_value=0, max_value=1, resolution=1,
+        siunit="", symbol="",
+    ),
+    OutputChannelType.AIR_TEMP_SETPOINT: ChannelSpec(
+        name="airTemperatureSetpoint", min_value=0, max_value=45, resolution=0.01,
+        siunit="celsius", symbol="°C",
+    ),
+}
+```
+
+Note: check the existing `CHANNEL_SPECS` in `output_channel.py` for the full list of channel types and preserve any entries not listed here. This step also simultaneously implements Task 2 (shade resolution fix) — shade channels get `resolution=100/65536`.
+
+- [ ] **Step 5: Add `siunit`/`symbol` to `get_description_properties()`**
+
+In `OutputChannel.get_description_properties()`, add the two fields:
+
+```python
+def get_description_properties(self) -> dict[str, Any]:
+    spec = get_channel_spec(self._channel_type)
+    props = {
+        "name": spec.name,
+        "channelType": int(self._channel_type),
+        "dsIndex": self._ds_index,
+        "min": spec.min_value,
+        "max": spec.max_value,
+        "resolution": spec.resolution,
+    }
+    if spec.siunit:
+        props["siunit"] = spec.siunit
+    if spec.symbol:
+        props["symbol"] = spec.symbol
+    return props
+```
+
+Only include the fields when non-empty so unknown/unspecified channels don't send empty strings.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+```bash
+pytest tests/test_output_channel.py -v
+```
+Expected: all pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/pydsvdcapi/output_channel.py tests/test_output_channel.py
+git commit -m "feat: add siunit/symbol to channelDescriptions; fix shade channel resolution to 16-bit"
+```
+
+---
+
+## Task 2: Fix shade channel resolution (already done in Task 1)
+
+This is folded into Task 1 Step 4 above — the shade channel `CHANNEL_SPECS` entries already use `resolution=100/65536`. No separate task needed.
+
+---
+
+## Task 3: Channel container keys — dsIndex everywhere (GET responses + push)
+
+**Files:**
+- Modify: `src/pydsvdcapi/output.py`
+- Modify: `src/pydsvdcapi/output_channel.py` (module docstring only)
+- Test: `tests/test_output_channel.py`
+- Test: `tests/test_output.py`
+
+**Scope:** All four locations that emit channel container keys now use `str(channel.ds_index)` (e.g. `"0"`, `"1"`), matching p44vdc exactly:
+
+1. `get_channel_descriptions()` — property GET response
+2. `get_channel_settings()` — property GET response
+3. `get_channel_states()` — property GET response
+4. `_push_channel_state()` — push notification
+
+**NOT changed:**
+- The `setOutputChannelValue` handler in `vdc_host.py` — it already resolves channels by `ch.name == notif.channelId` (name string), which is correct for API v3+ and independent of the property key format.
+- The `setProperty channelStates` handler in `vdc_host.py` — it also looks up by channel name (dSS sends name strings there too).
+
+The `deviceOutputIndex:255` errors that 0.8.6 addressed are now understood to have been caused by missing `siunit` (CRITICAL-1) and coarse resolution (CRITICAL-2), not by the key format. Aligning with p44vdc wire format here is the correct fix.
+
+- [ ] **Step 1: Write failing tests**
+
+In `tests/test_output_channel.py`:
+
+```python
+def test_channel_descriptions_keyed_by_dsindex(output_with_dimmer):
+    """channelDescriptions must be keyed by dsIndex string, not channel name."""
+    out = output_with_dimmer
+    desc = out.get_channel_descriptions()
+    ch = list(out.channels.values())[0]
+    assert str(ch.ds_index) in desc          # e.g. "0"
+    assert ch.name not in desc               # "brightness" must NOT be a key
+
+def test_channel_states_keyed_by_dsindex(output_with_dimmer):
+    out = output_with_dimmer
+    states = out.get_channel_states()
+    ch = list(out.channels.values())[0]
+    assert str(ch.ds_index) in states
+    assert ch.name not in states
+```
+
+In `tests/test_output.py`:
+
+```python
+async def test_push_channel_state_uses_dsindex_key(output_with_session):
+    """Push notification must key channelStates by dsIndex string."""
+    out, mock_session = output_with_session
+    ch = list(out.channels.values())[0]
+    ch.update_value(50.0)
+    await asyncio.sleep(0)
+
+    msg = mock_session.send_notification.call_args[0][0]
+    pushed = elements_to_dict(msg.vdc_send_push_notification.changedproperties)
+    channel_states = pushed.get("channelStates", {})
+    assert str(ch.ds_index) in channel_states
+    assert ch.name not in channel_states
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pytest tests/test_output_channel.py tests/test_output.py -k "dsindex" -v
+```
+Expected: FAIL — keys are channel name strings.
+
+- [ ] **Step 3: Update `get_channel_descriptions()`, `get_channel_settings()`, `get_channel_states()`**
+
+In `output.py`, change the three GET-response methods to key by dsIndex:
+
+```python
+def get_channel_descriptions(self) -> dict[str, Any]:
+    """Return ``channelDescriptions`` sub-tree keyed by dsIndex string.
+
+    Each key is the channel's numeric index as a string (e.g. ``"0"``,
+    ``"1"``), matching the p44vdc wire format.  The channel name is
+    carried inside each element as the ``name`` field.
+    """
+    return {
+        str(ch.ds_index): ch.get_description_properties()
+        for ch in self._channels.values()
+    }
+
+def get_channel_settings(self) -> dict[str, Any]:
+    """Return ``channelSettings`` sub-tree keyed by dsIndex string."""
+    return {
+        str(ch.ds_index): ch.get_settings_properties()
+        for ch in self._channels.values()
+    }
+
+def get_channel_states(self) -> dict[str, Any]:
+    """Return ``channelStates`` sub-tree keyed by dsIndex string."""
+    return {
+        str(ch.ds_index): ch.get_state_properties()
+        for ch in self._channels.values()
+    }
+```
+
+- [ ] **Step 4: Update `_push_channel_state()`**
+
+```python
+async def _push_channel_state(self, channel: OutputChannel) -> None:
+    """Push a single channel's state to the vdSM.
+
+    Sends a ``VDC_SEND_PUSH_NOTIFICATION`` with a ``channelStates``
+    payload keyed by the channel's **dsIndex** as a string (e.g.
+    ``{"channelStates": {"0": {"value": 75.0, …}}}``), matching
+    p44vdc wire format.
+    """
+    ...
+    state_dict = channel.get_state_properties()
+    push_tree: dict[str, Any] = {
+        "channelStates": {
+            str(channel.ds_index): state_dict,
+        }
+    }
+    ...
+```
+
+- [ ] **Step 5: Update module docstring in `output_channel.py`**
+
+The `.. important::` block currently says "dSS identifies channels by their name" and "use the channel name as the element key." Replace with:
+
+```
+.. important::
+
+   All three property sub-trees (``channelDescriptions``,
+   ``channelSettings``, ``channelStates``) and push notifications use
+   the channel's **dsIndex** as the element key (e.g. ``"0"``, ``"1"``),
+   matching the p44vdc wire format.  The channel name is carried as the
+   ``name`` field *inside* each element.
+
+   The ``setOutputChannelValue`` notification from dSS carries the
+   channel name in the ``channelId`` field (API v3+), which is resolved
+   by name-matching in :class:`~pydsvdcapi.vdc_host.VdcHost` — this
+   is independent of the property key format.
+```
+
+- [ ] **Step 6: Update existing tests that assert name-based keys**
+
+In `tests/test_output_channel.py`, update all assertions that previously checked for name-based keys (e.g. `assert "brightness" in desc`) to use dsIndex strings (e.g. `assert "0" in desc`). These were changed to name-based in 0.8.6 — revert them to dsIndex.
+
+- [ ] **Step 7: Run full output tests**
+
+```bash
+pytest tests/test_output_channel.py tests/test_output.py -v
+```
+Expected: all pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/pydsvdcapi/output.py src/pydsvdcapi/output_channel.py \
+        tests/test_output_channel.py tests/test_output.py
+git commit -m "fix: channel container keys use dsIndex (aligns with p44vdc wire format)"
+```
+
+---
+
+## Task 4: Shadow-specific `outputSettings` fields
+
+**Files:**
+- Modify: `src/pydsvdcapi/output.py`
+- Test: `tests/test_output.py`
+
+The five fields `openTime`, `closeTime`, `angleOpenTime`, `angleCloseTime`, `stopDelayTime` (all `float | None`) represent motor travel timing for shade devices. dSS reads and writes them. They must appear in `outputSettings` responses and be storable via `apply_settings()`.
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+def test_shadow_timing_fields_in_settings():
+    """Shadow timing fields appear in outputSettings when set."""
+    out = Output(vdsd=..., function=OutputFunction.POSITIONAL,
+                 output_usage=OutputUsage.UNDEFINED, name="output",
+                 default_group=16, active_group=16, groups={16},
+                 open_time=60.0, close_time=55.0,
+                 angle_open_time=1.5, angle_close_time=1.5,
+                 stop_delay_time=0.5)
+    s = out.get_settings_properties()
+    assert s["openTime"] == 60.0
+    assert s["closeTime"] == 55.0
+    assert s["angleOpenTime"] == 1.5
+    assert s["angleCloseTime"] == 1.5
+    assert s["stopDelayTime"] == 0.5
+
+def test_shadow_timing_absent_when_not_set():
+    """Shadow timing fields are absent when not configured."""
+    out = Output(vdsd=..., function=OutputFunction.POSITIONAL, ...)
+    s = out.get_settings_properties()
+    assert "openTime" not in s
+
+def test_apply_settings_stores_shadow_timing():
+    out = Output(...)
+    out.apply_settings({"openTime": 45.0, "closeTime": 40.0})
+    s = out.get_settings_properties()
+    assert s["openTime"] == 45.0
+    assert s["closeTime"] == 40.0
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pytest tests/test_output.py -k "shadow_timing" -v
+```
+Expected: FAIL — `TypeError` on unknown constructor arg, `KeyError` on settings.
+
+- [ ] **Step 3: Add shadow timing fields to `Output.__init__`**
+
+After the existing optional params, add:
+
+```python
+# Shadow motor timing (shade devices only, optional)
+open_time: float | None = None,
+close_time: float | None = None,
+angle_open_time: float | None = None,
+angle_close_time: float | None = None,
+stop_delay_time: float | None = None,
+```
+
+Store them:
+
+```python
+self._open_time: float | None = open_time
+self._close_time: float | None = close_time
+self._angle_open_time: float | None = angle_open_time
+self._angle_close_time: float | None = angle_close_time
+self._stop_delay_time: float | None = stop_delay_time
+```
+
+- [ ] **Step 4: Expose in `get_settings_properties()`**
+
+Add after the existing optional settings block:
+
+```python
+# Shadow motor timing (grey/shade devices — ShadowBehaviour fields).
+if self._open_time is not None:
+    settings["openTime"] = self._open_time
+if self._close_time is not None:
+    settings["closeTime"] = self._close_time
+if self._angle_open_time is not None:
+    settings["angleOpenTime"] = self._angle_open_time
+if self._angle_close_time is not None:
+    settings["angleCloseTime"] = self._angle_close_time
+if self._stop_delay_time is not None:
+    settings["stopDelayTime"] = self._stop_delay_time
+```
+
+- [ ] **Step 5: Handle in `apply_settings()`**
+
+Add to the existing `apply_settings()` method:
+
+```python
+if "openTime" in settings:
+    val = settings["openTime"]
+    self._open_time = float(val) if val is not None else None
+if "closeTime" in settings:
+    val = settings["closeTime"]
+    self._close_time = float(val) if val is not None else None
+if "angleOpenTime" in settings:
+    val = settings["angleOpenTime"]
+    self._angle_open_time = float(val) if val is not None else None
+if "angleCloseTime" in settings:
+    val = settings["angleCloseTime"]
+    self._angle_close_time = float(val) if val is not None else None
+if "stopDelayTime" in settings:
+    val = settings["stopDelayTime"]
+    self._stop_delay_time = float(val) if val is not None else None
+```
+
+- [ ] **Step 6: Add to persistence (save/restore)**
+
+Locate the `_save_state()` / `_apply_state()` / `to_dict()` / `from_dict()` methods in `output.py` and add the five fields. Follow the existing pattern for optional float fields (e.g. `onThreshold`).
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+```bash
+pytest tests/test_output.py -k "shadow_timing" -v
+```
+Expected: all pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/pydsvdcapi/output.py tests/test_output.py
+git commit -m "feat: add shadow motor timing fields to outputSettings (openTime/closeTime/angleOpenTime/angleCloseTime/stopDelayTime)"
+```
+
+---
+
+## Task 5: Add `transitionTime` to `outputState`
+
+**Files:**
+- Modify: `src/pydsvdcapi/output.py`
+- Test: `tests/test_output.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_output_state_includes_transition_time():
+    out = Output(...)
+    state = out.get_state_properties()
+    assert "transitionTime" in state
+    assert isinstance(state["transitionTime"], float)
+
+def test_apply_state_stores_transition_time():
+    out = Output(...)
+    out.apply_state({"transitionTime": 0.5})
+    assert out.get_state_properties()["transitionTime"] == 0.5
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pytest tests/test_output.py -k "transition_time" -v
+```
+Expected: FAIL — `KeyError: 'transitionTime'`.
+
+- [ ] **Step 3: Add `_transition_time` to `Output.__init__`**
+
+```python
+self._transition_time: float = 0.0
+```
+
+- [ ] **Step 4: Expose in `get_state_properties()`**
+
+```python
+def get_state_properties(self) -> dict[str, Any]:
+    return {
+        "localPriority": self._local_priority,
+        "transitionTime": self._transition_time,
+        "error": int(self._error),
+    }
+```
+
+- [ ] **Step 5: Handle in `apply_state()`**
+
+Find `apply_state()` and add:
+
+```python
+if "transitionTime" in state:
+    val = state["transitionTime"]
+    self._transition_time = float(val) if val is not None else 0.0
+```
+
+Also expose a `transition_time` setter property so device code can update it when a transition starts/ends.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+```bash
+pytest tests/test_output.py -k "transition_time" -v
+```
+Expected: all pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/pydsvdcapi/output.py tests/test_output.py
+git commit -m "feat: add transitionTime to outputState (matches p44vdc outputStateProperties)"
+```
+
+---
+
+## Task 6: Store unknown `setProperty` keys instead of silently dropping them
+
+**Files:**
+- Modify: `src/pydsvdcapi/output.py`
+- Test: `tests/test_output.py`
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+def test_apply_settings_stores_unknown_key():
+    out = Output(...)
+    out.apply_settings({"someUnknownKey": 42.0, "anotherKey": "hello"})
+    s = out.get_settings_properties()
+    assert s["someUnknownKey"] == 42.0
+    assert s["anotherKey"] == "hello"
+
+def test_apply_settings_unknown_key_does_not_shadow_known():
+    out = Output(...)
+    out.apply_settings({"mode": 2, "someUnknownKey": 99})
+    s = out.get_settings_properties()
+    assert s["mode"] == 2          # known field handled normally
+    assert s["someUnknownKey"] == 99  # unknown field stored
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pytest tests/test_output.py -k "unknown_key" -v
+```
+Expected: FAIL — unknown keys are silently dropped.
+
+- [ ] **Step 3: Add `_extra_settings` to `Output.__init__`**
+
+```python
+self._extra_settings: dict[str, Any] = {}
+```
+
+- [ ] **Step 4: Store unknown keys in `apply_settings()`**
+
+The known keys form a static set. After processing all known keys, collect anything left:
+
+```python
+_KNOWN_SETTING_KEYS: frozenset[str] = frozenset({
+    "mode", "activeGroup", "pushChanges", "groups",
+    "onThreshold", "minBrightness",
+    "dimTimeUp", "dimTimeDown",
+    "dimTimeUpAlt1", "dimTimeDownAlt1",
+    "dimTimeUpAlt2", "dimTimeDownAlt2",
+    "heatingSystemCapability", "heatingSystemType",
+    "openTime", "closeTime",
+    "angleOpenTime", "angleCloseTime",
+    "stopDelayTime",
+})
+```
+
+At the end of `apply_settings()`:
+
+```python
+for key, val in settings.items():
+    if key not in _KNOWN_SETTING_KEYS:
+        self._extra_settings[key] = val
+        logger.debug("outputSettings: stored unknown key '%s' = %r", key, val)
+```
+
+- [ ] **Step 5: Include `_extra_settings` in `get_settings_properties()`**
+
+At the end of `get_settings_properties()`:
+
+```python
+# Unknown keys received via setProperty — returned verbatim.
+settings.update(self._extra_settings)
+return settings
+```
+
+- [ ] **Step 6: Add to persistence**
+
+In save/restore, include `_extra_settings` as a dict under a key like `"_extraSettings"`.
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+```bash
+pytest tests/test_output.py -k "unknown_key" -v
+```
+Expected: all pass.
+
+- [ ] **Step 8: Run full test suite**
+
+```bash
+pytest tests/ -q
+```
+Expected: all pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/pydsvdcapi/output.py tests/test_output.py
+git commit -m "feat: store unknown outputSettings keys from setProperty instead of silently dropping them"
+```
+
+---
+
+## Final Steps
+
+- [ ] **Update CHANGELOG.md** — add `## [0.8.8]` section describing all six changes.
+
+- [ ] **Bump version** — `pyproject.toml` and `__init__.py` to `"0.8.8"`.
+
+- [ ] **Run ruff format + check**
+
+```bash
+ruff format src/ tests/ examples/
+ruff check src/ tests/ examples/
+```
+
+- [ ] **Full test suite**
+
+```bash
+pytest tests/ -q
+```
+
+- [ ] **Final commit**
+
+```bash
+git commit -m "release: bump version to 0.8.8"
+```

--- a/docs/vdc-api-properties.md
+++ b/docs/vdc-api-properties.md
@@ -915,6 +915,8 @@ Writable, persistently stored. The dSS firmware reads `heatingSystemType` from t
 |---|---|---|---|---|
 | `localPriority` | r/w | boolean | When `true`, output ignores scene calls unless the scene has `ignoreLocalPriority` set or the call uses `force=true`. | Stored. Prevents remote scene calls from overriding local operation. |
 | `error` | r | integer enum | Output error status — see table below. | Shown in configurator as device error indicator. |
+| `transitionTime` | r/w | double | Time in seconds for the ongoing output transition. `0.0` when idle. | Not currently used by dSS firmware; carried for wire-format compatibility with p44vdc. |
+| `movingState` | r/w | integer | Motor movement state for shade/blind outputs: `0` = idle, `1` = moving open/up, `-1` = moving closed/down. | Not currently read by dSS firmware; carried for wire-format compatibility with p44vdc `ShadowBehaviour`. |
 
 **error values** (`OutputError`, Python):
 
@@ -934,7 +936,7 @@ Writable, persistently stored. The dSS firmware reads `heatingSystemType` from t
 
 An output has zero or more channels. Each channel controls one independent physical dimension of the output (brightness, color, shade position, etc.). Channel index 0 is the primary/default channel.
 
-> **Key format — critical:** `channelDescriptions`, `channelSettings`, and `channelStates` are each transmitted as a **single** `PropertyElement` whose child elements are keyed by the channel's **name string** (e.g. `"brightness"`, `"colortemp"`), **not** by the numeric `dsIndex`.  dSS registers channels by name internally; using integer-string keys (e.g. `"0"`, `"1"`) causes `deviceOutputIndex:255` errors on every channel lookup and sets the wrong output channel in scenes.  The `channelId` field in `setOutputChannelValue` notifications also carries the name string.
+> **Key format:** `channelDescriptions`, `channelSettings`, and `channelStates` are each transmitted as a **single** `PropertyElement` whose child elements are keyed by the channel's **dsIndex as a string** (e.g. `"0"`, `"1"`), matching the p44vdc wire format.  The channel name is carried as the `name` field *inside* each element.  The `channelId` field in `setOutputChannelValue` notifications carries the name string; `VdcHost` resolves channels by that name — this is independent of the property-tree key format.
 
 #### 4.4.1 Channel Description (`channelDescriptions`)
 
@@ -946,6 +948,8 @@ An output has zero or more channels. Each channel controls one independent physi
 | `min` | r | double | Minimum channel value. | Used as the "off" value in scenes and dim-to-minimum calls. |
 | `max` | r | double | Maximum channel value. | Used as the "on" / dim-to-maximum value. |
 | `resolution` | r | double | Value of the LSB (precision). | Used for value quantization. |
+| `siunit` | r | string | SI unit name (e.g. `"percent"`, `"degree"`, `"reciprocal megakelvin"`, `"celsius"`). Optional — absent for dimensionless channels. | Used by dSS firmware for channel value validation and unit display. |
+| `symbol` | r | string | Unit symbol string (e.g. `"%"`, `"°"`, `"mired"`, `"°C"`). Optional — absent for dimensionless channels. | Shown in the dSS configurator channel value displays. |
 
 **channelType values** — firmware-verified from `ChannelType` enum in `modelconst.h`:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pydsvdcapi"
-version = "0.8.7"
+version = "0.8.8"
 description = "Python library for the digitalSTROM vDC API"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/pydsvdcapi/__init__.py
+++ b/src/pydsvdcapi/__init__.py
@@ -1,6 +1,6 @@
 """pydsvdcapi - Python library for the DSvDC API."""
 
-__version__ = "0.8.7"
+__version__ = "0.8.8"
 
 __all__ = [
     # Version

--- a/src/pydsvdcapi/output.py
+++ b/src/pydsvdcapi/output.py
@@ -45,7 +45,8 @@ State model
 
 The output's operational values (brightness level, valve position,
 colour values, etc.) live in the *channels*.  The output state itself
-carries ``localPriority``, ``transitionTime``, and ``error``.
+carries ``localPriority``, ``transitionTime``, ``movingState``, and
+``error``.
 
 When a channel value is changed locally (from the device side) and
 ``pushChanges`` is enabled, the output pushes the channel state to
@@ -56,7 +57,8 @@ Persistence
 
 Only description and settings properties are persisted (via the owning
 Vdsd's property tree → Device → Vdc → VdcHost YAML).  The runtime
-state (``localPriority``, ``transitionTime``, ``error``) is transient.
+state (``localPriority``, ``transitionTime``, ``movingState``, ``error``)
+is transient.
 
 Usage::
 
@@ -183,23 +185,20 @@ _KNOWN_SETTING_KEYS: frozenset[str] = frozenset(
 #: All keys that appear in the persisted property tree dict.
 #: Used by :meth:`Output._apply_state` to identify which keys are
 #: firmware-specific extras that should be stored in :attr:`Output._extra_settings`.
-_KNOWN_TREE_KEYS: frozenset[str] = (
-    _KNOWN_SETTING_KEYS
-    | frozenset(
-        {
-            # Description keys
-            "function",
-            "outputUsage",
-            "name",
-            "defaultGroup",
-            "variableRamp",
-            "maxPower",
-            "activeCoolingMode",
-            # Structural keys
-            "channels",
-            "scenes",
-        }
-    )
+_KNOWN_TREE_KEYS: frozenset[str] = _KNOWN_SETTING_KEYS | frozenset(
+    {
+        # Description keys
+        "function",
+        "outputUsage",
+        "name",
+        "defaultGroup",
+        "variableRamp",
+        "maxPower",
+        "activeCoolingMode",
+        # Structural keys
+        "channels",
+        "scenes",
+    }
 )
 
 
@@ -600,6 +599,7 @@ class Output:
         self._local_priority: bool = False
         self._error: OutputError = OutputError.OK
         self._transition_time: float = 0.0
+        self._moving_state: int = 0
 
         # ---- session reference (set on announcement) -----------------
         self._session: VdcSession | None = None
@@ -929,6 +929,19 @@ class Output:
     @transition_time.setter
     def transition_time(self, value: float) -> None:
         self._transition_time = float(value)
+
+    @property
+    def moving_state(self) -> int:
+        """Motor movement state for shade/blind outputs (volatile, not persisted).
+
+        ``0`` = idle, ``1`` = moving open/up, ``-1`` = moving closed/down.
+        Matches p44vdc ``ShadowBehaviour`` wire format.
+        """
+        return self._moving_state
+
+    @moving_state.setter
+    def moving_state(self, value: int) -> None:
+        self._moving_state = int(value)
 
     # ==================================================================
     # Channel management
@@ -1716,12 +1729,14 @@ class Output:
         Keys match the vDC API property names (§4.8.3).
 
         Includes ``localPriority``, ``transitionTime`` (float, seconds),
-        and ``error``.  All three are volatile runtime state and are not
-        persisted to YAML.
+        ``movingState`` (integer, motor movement state for shade/blind
+        outputs), and ``error``.  All are volatile runtime state and are
+        not persisted to YAML.
         """
         return {
             "localPriority": self._local_priority,
             "transitionTime": self._transition_time,
+            "movingState": self._moving_state,
             "error": int(self._error),
         }
 
@@ -1822,14 +1837,17 @@ class Output:
         Called by :meth:`VdcHost._apply_vdsd_set_property` when the
         vdSM sends a ``VDSM_SEND_SET_PROPERTY`` for ``outputState``.
 
-        Recognised keys: ``localPriority``, ``transitionTime``.
-        Unknown keys are silently ignored.
+        Recognised keys: ``localPriority``, ``transitionTime``,
+        ``movingState``.  Unknown keys are silently ignored.
         """
         if "localPriority" in state:
             self._local_priority = bool(state["localPriority"])
         if "transitionTime" in state:
             val = state["transitionTime"]
             self._transition_time = float(val) if val is not None else 0.0
+        if "movingState" in state:
+            val = state["movingState"]
+            self._moving_state = int(val) if val is not None else 0
 
     # ==================================================================
     # Persistence (property tree)

--- a/src/pydsvdcapi/output.py
+++ b/src/pydsvdcapi/output.py
@@ -153,6 +153,55 @@ FUNCTION_CHANNELS: dict[OutputFunction, list[OutputChannelType]] = {
 
 logger = logging.getLogger(__name__)
 
+#: All setting keys that :meth:`Output.apply_settings` handles explicitly.
+#: Any key arriving via ``setProperty`` that is **not** in this set is stored
+#: in :attr:`Output._extra_settings` and round-tripped through persistence.
+_KNOWN_SETTING_KEYS: frozenset[str] = frozenset(
+    {
+        "mode",
+        "activeGroup",
+        "pushChanges",
+        "groups",
+        "onThreshold",
+        "minBrightness",
+        "dimTimeUp",
+        "dimTimeDown",
+        "dimTimeUpAlt1",
+        "dimTimeDownAlt1",
+        "dimTimeUpAlt2",
+        "dimTimeDownAlt2",
+        "heatingSystemCapability",
+        "heatingSystemType",
+        "openTime",
+        "closeTime",
+        "angleOpenTime",
+        "angleCloseTime",
+        "stopDelayTime",
+    }
+)
+
+#: All keys that appear in the persisted property tree dict.
+#: Used by :meth:`Output._apply_state` to identify which keys are
+#: firmware-specific extras that should be stored in :attr:`Output._extra_settings`.
+_KNOWN_TREE_KEYS: frozenset[str] = (
+    _KNOWN_SETTING_KEYS
+    | frozenset(
+        {
+            # Description keys
+            "function",
+            "outputUsage",
+            "name",
+            "defaultGroup",
+            "variableRamp",
+            "maxPower",
+            "activeCoolingMode",
+            # Structural keys
+            "channels",
+            "scenes",
+        }
+    )
+)
+
 
 # ---------------------------------------------------------------------------
 # Scene default helpers
@@ -541,6 +590,11 @@ class Output:
         self._angle_open_time: float | None = angle_open_time
         self._angle_close_time: float | None = angle_close_time
         self._stop_delay_time: float | None = stop_delay_time
+
+        # Extra settings: unknown keys received via setProperty are stored
+        # here so they can be round-tripped through persistence and returned
+        # by get_settings_properties().
+        self._extra_settings: dict[str, Any] = {}
 
         # ---- state properties (volatile, NOT persisted) --------------
         self._local_priority: bool = False
@@ -1650,6 +1704,10 @@ class Output:
         if self._stop_delay_time is not None:
             settings["stopDelayTime"] = self._stop_delay_time
 
+        # Include any extra (firmware-specific) settings that arrived via
+        # setProperty but are not in the standard known-key set.
+        settings.update(self._extra_settings)
+
         return settings
 
     def get_state_properties(self) -> dict[str, Any]:
@@ -1676,7 +1734,9 @@ class Output:
 
         Called by :meth:`VdcHost._apply_vdsd_set_property` when the
         vdSM sends a ``VDSM_SEND_SET_PROPERTY`` for
-        ``outputSettings``.  Unknown keys are silently ignored.
+        ``outputSettings``.  Unknown keys are stored in
+        :attr:`_extra_settings` and returned by
+        :meth:`get_settings_properties`.
 
         Recognised shadow motor timing keys: ``openTime``, ``closeTime``,
         ``angleOpenTime``, ``angleCloseTime``, ``stopDelayTime``.
@@ -1746,6 +1806,13 @@ class Output:
         if "stopDelayTime" in settings:
             val = settings["stopDelayTime"]
             self._stop_delay_time = float(val) if val is not None else None
+
+        # Collect any keys not handled above into _extra_settings so they
+        # can be round-tripped through persistence and returned by
+        # get_settings_properties().
+        for key, val in settings.items():
+            if key not in _KNOWN_SETTING_KEYS:
+                self._extra_settings[key] = val
 
         self._schedule_auto_save()
 
@@ -1832,6 +1899,10 @@ class Output:
             tree["angleCloseTime"] = self._angle_close_time
         if self._stop_delay_time is not None:
             tree["stopDelayTime"] = self._stop_delay_time
+
+        # Extra (firmware-specific) settings — persisted alongside known keys.
+        if self._extra_settings:
+            tree.update(self._extra_settings)
 
         # Channels (description metadata only, not values).
         if self._channels:
@@ -1933,6 +2004,13 @@ class Output:
             self._angle_close_time = float(state["angleCloseTime"])
         if "stopDelayTime" in state:
             self._stop_delay_time = float(state["stopDelayTime"])
+
+        # Restore extra (firmware-specific) settings: any key in the
+        # persisted tree that is not a known description, settings, or
+        # structural key is treated as an extra setting.
+        for key, val in state.items():
+            if key not in _KNOWN_TREE_KEYS:
+                self._extra_settings[key] = val
 
         # Restore channels.
         if "channels" in state:

--- a/src/pydsvdcapi/output.py
+++ b/src/pydsvdcapi/output.py
@@ -437,6 +437,17 @@ class Output:
     heating_system_type:
         Kind of valve / actuator attached.  ``None`` if not a climate
         device.
+    open_time:
+        Motor open travel time in seconds (ShadowBehaviour / p44vdc).
+        ``None`` if not a shadow device.
+    close_time:
+        Motor close travel time in seconds.  ``None`` if not configured.
+    angle_open_time:
+        Blade angle open time in seconds.  ``None`` if not configured.
+    angle_close_time:
+        Blade angle close time in seconds.  ``None`` if not configured.
+    stop_delay_time:
+        Stop delay time in seconds.  ``None`` if not configured.
     """
 
     def __init__(
@@ -465,6 +476,12 @@ class Output:
         dim_time_down_alt2: int | None = None,
         heating_system_capability: HeatingSystemCapability | int | None = None,
         heating_system_type: HeatingSystemType | int | None = None,
+        # Shadow motor timing settings (ShadowBehaviour / p44vdc)
+        open_time: float | None = None,
+        close_time: float | None = None,
+        angle_open_time: float | None = None,
+        angle_close_time: float | None = None,
+        stop_delay_time: float | None = None,
     ) -> None:
         # ---- parent reference ----------------------------------------
         self._vdsd: Vdsd = vdsd
@@ -517,6 +534,13 @@ class Output:
             if heating_system_type is not None
             else None
         )
+
+        # Shadow motor timing (ShadowBehaviour / p44vdc outputSettings)
+        self._open_time: float | None = open_time
+        self._close_time: float | None = close_time
+        self._angle_open_time: float | None = angle_open_time
+        self._angle_close_time: float | None = angle_close_time
+        self._stop_delay_time: float | None = stop_delay_time
 
         # ---- state properties (volatile, NOT persisted) --------------
         self._local_priority: bool = False
@@ -768,6 +792,56 @@ class Output:
         self._heating_system_type = (
             HeatingSystemType(int(value)) if value is not None else None
         )
+        self._schedule_auto_save()
+
+    @property
+    def open_time(self) -> float | None:
+        """Motor open travel time in seconds (``None`` = not configured)."""
+        return self._open_time
+
+    @open_time.setter
+    def open_time(self, value: float | None) -> None:
+        self._open_time = value
+        self._schedule_auto_save()
+
+    @property
+    def close_time(self) -> float | None:
+        """Motor close travel time in seconds (``None`` = not configured)."""
+        return self._close_time
+
+    @close_time.setter
+    def close_time(self, value: float | None) -> None:
+        self._close_time = value
+        self._schedule_auto_save()
+
+    @property
+    def angle_open_time(self) -> float | None:
+        """Blade angle open time in seconds (``None`` = not configured)."""
+        return self._angle_open_time
+
+    @angle_open_time.setter
+    def angle_open_time(self, value: float | None) -> None:
+        self._angle_open_time = value
+        self._schedule_auto_save()
+
+    @property
+    def angle_close_time(self) -> float | None:
+        """Blade angle close time in seconds (``None`` = not configured)."""
+        return self._angle_close_time
+
+    @angle_close_time.setter
+    def angle_close_time(self, value: float | None) -> None:
+        self._angle_close_time = value
+        self._schedule_auto_save()
+
+    @property
+    def stop_delay_time(self) -> float | None:
+        """Stop delay time in seconds (``None`` = not configured)."""
+        return self._stop_delay_time
+
+    @stop_delay_time.setter
+    def stop_delay_time(self, value: float | None) -> None:
+        self._stop_delay_time = value
         self._schedule_auto_save()
 
     # ==================================================================
@@ -1516,6 +1590,10 @@ class Output:
         """Return the ``outputSettings`` property dict.
 
         Keys match the vDC API property names (§4.8.2).
+
+        Optional shadow motor timing fields (``openTime``, ``closeTime``,
+        ``angleOpenTime``, ``angleCloseTime``, ``stopDelayTime``) are only
+        included when they have been set to a non-``None`` value.
         """
         settings: dict[str, Any] = {
             "mode": int(self._mode),
@@ -1550,6 +1628,18 @@ class Output:
         if self._heating_system_type is not None:
             settings["heatingSystemType"] = int(self._heating_system_type)
 
+        # Optional shadow motor timing settings (ShadowBehaviour / p44vdc).
+        if self._open_time is not None:
+            settings["openTime"] = self._open_time
+        if self._close_time is not None:
+            settings["closeTime"] = self._close_time
+        if self._angle_open_time is not None:
+            settings["angleOpenTime"] = self._angle_open_time
+        if self._angle_close_time is not None:
+            settings["angleCloseTime"] = self._angle_close_time
+        if self._stop_delay_time is not None:
+            settings["stopDelayTime"] = self._stop_delay_time
+
         return settings
 
     def get_state_properties(self) -> dict[str, Any]:
@@ -1572,6 +1662,10 @@ class Output:
         Called by :meth:`VdcHost._apply_vdsd_set_property` when the
         vdSM sends a ``VDSM_SEND_SET_PROPERTY`` for
         ``outputSettings``.  Unknown keys are silently ignored.
+
+        Recognised shadow motor timing keys: ``openTime``, ``closeTime``,
+        ``angleOpenTime``, ``angleCloseTime``, ``stopDelayTime``.
+        Pass ``None`` to clear a previously set value.
         """
         if "mode" in settings:
             self._mode = OutputMode(int(settings["mode"]))
@@ -1622,6 +1716,21 @@ class Output:
             self._heating_system_type = (
                 HeatingSystemType(int(val)) if val is not None else None
             )
+        if "openTime" in settings:
+            val = settings["openTime"]
+            self._open_time = float(val) if val is not None else None
+        if "closeTime" in settings:
+            val = settings["closeTime"]
+            self._close_time = float(val) if val is not None else None
+        if "angleOpenTime" in settings:
+            val = settings["angleOpenTime"]
+            self._angle_open_time = float(val) if val is not None else None
+        if "angleCloseTime" in settings:
+            val = settings["angleCloseTime"]
+            self._angle_close_time = float(val) if val is not None else None
+        if "stopDelayTime" in settings:
+            val = settings["stopDelayTime"]
+            self._stop_delay_time = float(val) if val is not None else None
 
         self._schedule_auto_save()
 
@@ -1690,6 +1799,18 @@ class Output:
             tree["heatingSystemCapability"] = int(self._heating_system_capability)
         if self._heating_system_type is not None:
             tree["heatingSystemType"] = int(self._heating_system_type)
+
+        # Optional shadow motor timing settings.
+        if self._open_time is not None:
+            tree["openTime"] = self._open_time
+        if self._close_time is not None:
+            tree["closeTime"] = self._close_time
+        if self._angle_open_time is not None:
+            tree["angleOpenTime"] = self._angle_open_time
+        if self._angle_close_time is not None:
+            tree["angleCloseTime"] = self._angle_close_time
+        if self._stop_delay_time is not None:
+            tree["stopDelayTime"] = self._stop_delay_time
 
         # Channels (description metadata only, not values).
         if self._channels:
@@ -1781,6 +1902,16 @@ class Output:
             self._heating_system_type = HeatingSystemType(
                 int(state["heatingSystemType"])
             )
+        if "openTime" in state:
+            self._open_time = float(state["openTime"])
+        if "closeTime" in state:
+            self._close_time = float(state["closeTime"])
+        if "angleOpenTime" in state:
+            self._angle_open_time = float(state["angleOpenTime"])
+        if "angleCloseTime" in state:
+            self._angle_close_time = float(state["angleCloseTime"])
+        if "stopDelayTime" in state:
+            self._stop_delay_time = float(state["stopDelayTime"])
 
         # Restore channels.
         if "channels" in state:

--- a/src/pydsvdcapi/output.py
+++ b/src/pydsvdcapi/output.py
@@ -33,10 +33,9 @@ are auto-created on construction:
 The ``channelDescriptions``, ``channelSettings``, and
 ``channelStates`` property sub-trees each carry **all channels inside
 a single** ``PropertyElement``, with each channel identified by its
-**name** as the element key (e.g. ``"brightness"``, ``"colortemp"``).
-Using the numeric ``dsIndex`` as the key (the former behaviour) caused
-``deviceOutputIndex:255`` errors because dSS registers channels by name
-and cannot match integer-string keys.
+**dsIndex** as the element key (e.g. ``"0"``, ``"1"``), matching the
+p44vdc wire format.  The channel name is carried as the ``name`` field
+inside each element.
 
 See :mod:`pydsvdcapi.output_channel` for details on channel semantics,
 bidirectional value flow, ``apply_now`` buffering, and push behaviour.
@@ -1410,9 +1409,10 @@ class Output:
 
         Called by :meth:`OutputChannel.update_value` when ``pushChanges``
         is set on this output.  Sends a ``VDC_SEND_PUSH_NOTIFICATION``
-        with a ``channelStates`` payload keyed by the channel's **name**
-        (e.g. ``{"channelStates": {"brightness": {"value": 75.0, …}}}``),
-        matching the same keying used in ``getProperty`` responses.
+        with a ``channelStates`` payload keyed by the channel's **dsIndex**
+        string (e.g. ``{"channelStates": {"0": {"value": 75.0, …}}}``),
+        matching the p44vdc wire format and the same keying used in
+        ``getProperty`` responses.
         """
         session = self._session
         if session is None:
@@ -1426,7 +1426,7 @@ class Output:
         state_dict = channel.get_state_properties()
         push_tree: dict[str, Any] = {
             "channelStates": {
-                channel.name: state_dict,
+                str(channel.ds_index): state_dict,
             }
         }
 
@@ -1457,33 +1457,38 @@ class Output:
     # ==================================================================
 
     def get_channel_descriptions(self) -> dict[str, Any]:
-        """Return the ``channelDescriptions`` sub-tree keyed by channel name.
+        """Return the ``channelDescriptions`` sub-tree keyed by dsIndex string.
 
-        Each key is the channel's protocol name (e.g. ``"brightness"``,
-        ``"colortemp"``).  The value is the dict from
-        :meth:`~pydsvdcapi.output_channel.OutputChannel.get_description_properties`.
-
-        dSS registers channels by name; using ``dsIndex`` strings as keys
-        would cause ``deviceOutputIndex:255`` errors on every channel lookup.
+        Each key is the channel's ``dsIndex`` as a string (e.g. ``"0"``,
+        ``"1"``), matching the p44vdc wire format.  The value is the dict from
+        :meth:`~pydsvdcapi.output_channel.OutputChannel.get_description_properties`,
+        which carries the channel name as the ``name`` field inside each element.
         """
         return {
-            ch.name: ch.get_description_properties() for ch in self._channels.values()
+            str(ch.ds_index): ch.get_description_properties()
+            for ch in self._channels.values()
         }
 
     def get_channel_settings(self) -> dict[str, Any]:
-        """Return the ``channelSettings`` sub-tree keyed by channel name.
+        """Return the ``channelSettings`` sub-tree keyed by dsIndex string.
 
-        Keys are channel names, consistent with :meth:`get_channel_descriptions`.
+        Keys are dsIndex strings, consistent with :meth:`get_channel_descriptions`.
         Currently all channels return an empty settings dict (§4.9.2).
         """
-        return {ch.name: ch.get_settings_properties() for ch in self._channels.values()}
+        return {
+            str(ch.ds_index): ch.get_settings_properties()
+            for ch in self._channels.values()
+        }
 
     def get_channel_states(self) -> dict[str, Any]:
-        """Return the ``channelStates`` sub-tree keyed by channel name.
+        """Return the ``channelStates`` sub-tree keyed by dsIndex string.
 
-        Keys are channel names, consistent with :meth:`get_channel_descriptions`.
+        Keys are dsIndex strings, consistent with :meth:`get_channel_descriptions`.
         """
-        return {ch.name: ch.get_state_properties() for ch in self._channels.values()}
+        return {
+            str(ch.ds_index): ch.get_state_properties()
+            for ch in self._channels.values()
+        }
 
     # ==================================================================
     # Property dicts (for getProperty responses)

--- a/src/pydsvdcapi/output.py
+++ b/src/pydsvdcapi/output.py
@@ -12,7 +12,7 @@ The output owns three property groups visible to the vdSM:
   (function, outputUsage, variableRamp, maxPower, …).
 * **outputSettings** — writable configuration stored persistently
   (mode, groups, pushChanges, dimming parameters, …).
-* **outputState** — volatile runtime state (localPriority, error)
+* **outputState** — volatile runtime state (localPriority, transitionTime, error)
   that is **not** persisted.
 
 Channels
@@ -45,7 +45,7 @@ State model
 
 The output's operational values (brightness level, valve position,
 colour values, etc.) live in the *channels*.  The output state itself
-only carries ``localPriority`` and ``error``.
+carries ``localPriority``, ``transitionTime``, and ``error``.
 
 When a channel value is changed locally (from the device side) and
 ``pushChanges`` is enabled, the output pushes the channel state to
@@ -56,7 +56,7 @@ Persistence
 
 Only description and settings properties are persisted (via the owning
 Vdsd's property tree → Device → Vdc → VdcHost YAML).  The runtime
-state (``localPriority``, ``error``) is transient.
+state (``localPriority``, ``transitionTime``, ``error``) is transient.
 
 Usage::
 
@@ -545,6 +545,7 @@ class Output:
         # ---- state properties (volatile, NOT persisted) --------------
         self._local_priority: bool = False
         self._error: OutputError = OutputError.OK
+        self._transition_time: float = 0.0
 
         # ---- session reference (set on announcement) -----------------
         self._session: VdcSession | None = None
@@ -865,6 +866,15 @@ class Output:
     @error.setter
     def error(self, value: OutputError | int) -> None:
         self._error = OutputError(int(value))
+
+    @property
+    def transition_time(self) -> float:
+        """Transition time in seconds (volatile, not persisted)."""
+        return self._transition_time
+
+    @transition_time.setter
+    def transition_time(self, value: float) -> None:
+        self._transition_time = float(value)
 
     # ==================================================================
     # Channel management
@@ -1646,9 +1656,14 @@ class Output:
         """Return the ``outputState`` property dict.
 
         Keys match the vDC API property names (§4.8.3).
+
+        Includes ``localPriority``, ``transitionTime`` (float, seconds),
+        and ``error``.  All three are volatile runtime state and are not
+        persisted to YAML.
         """
         return {
             "localPriority": self._local_priority,
+            "transitionTime": self._transition_time,
             "error": int(self._error),
         }
 
@@ -1739,9 +1754,15 @@ class Output:
 
         Called by :meth:`VdcHost._apply_vdsd_set_property` when the
         vdSM sends a ``VDSM_SEND_SET_PROPERTY`` for ``outputState``.
+
+        Recognised keys: ``localPriority``, ``transitionTime``.
+        Unknown keys are silently ignored.
         """
         if "localPriority" in state:
             self._local_priority = bool(state["localPriority"])
+        if "transitionTime" in state:
+            val = state["transitionTime"]
+            self._transition_time = float(val) if val is not None else 0.0
 
     # ==================================================================
     # Persistence (property tree)

--- a/src/pydsvdcapi/output_channel.py
+++ b/src/pydsvdcapi/output_channel.py
@@ -124,12 +124,19 @@ class ChannelSpec:
         Maximum value in the channel's unit.
     resolution:
         Default resolution (smallest distinguishable step).
+    siunit:
+        SI unit name (e.g. ``"percent"``, ``"degree"``).  Empty string
+        for dimensionless / boolean channels.
+    symbol:
+        Unit symbol (e.g. ``"%"``, ``"°"``).  Empty string when no unit.
     """
 
     name: str
     min_value: float
     max_value: float
     resolution: float
+    siunit: str = ""
+    symbol: str = ""
 
 
 #: Metadata table for all standard channel types (vDC API §4.9.4).
@@ -137,53 +144,89 @@ class ChannelSpec:
 CHANNEL_SPECS: dict[OutputChannelType, ChannelSpec] = {
     # -- Light channels ------------------------------------------------
     OutputChannelType.BRIGHTNESS: ChannelSpec(
-        name="brightness", min_value=0, max_value=100, resolution=100 / 255
+        name="brightness",
+        min_value=0,
+        max_value=100,
+        resolution=100 / 255,
+        siunit="percent",
+        symbol="%",
     ),
     OutputChannelType.HUE: ChannelSpec(
-        name="hue", min_value=0, max_value=360, resolution=360 / 255
+        name="hue",
+        min_value=0,
+        max_value=360,
+        resolution=360 / 255,
+        siunit="degree",
+        symbol="°",
     ),
     OutputChannelType.SATURATION: ChannelSpec(
-        name="saturation", min_value=0, max_value=100, resolution=100 / 255
+        name="saturation",
+        min_value=0,
+        max_value=100,
+        resolution=100 / 255,
+        siunit="percent",
+        symbol="%",
     ),
     OutputChannelType.COLOR_TEMPERATURE: ChannelSpec(
-        name="colortemp", min_value=100, max_value=1000, resolution=900 / 255
+        name="colortemp",
+        min_value=100,
+        max_value=1000,
+        resolution=900 / 255,
+        siunit="reciprocal megakelvin",
+        symbol="mired",
     ),
     OutputChannelType.CIE_X: ChannelSpec(
-        name="x", min_value=0, max_value=10000, resolution=10000 / 255
+        name="x",
+        min_value=0,
+        max_value=10000,
+        resolution=10000 / 255,
     ),
     OutputChannelType.CIE_Y: ChannelSpec(
-        name="y", min_value=0, max_value=10000, resolution=10000 / 255
+        name="y",
+        min_value=0,
+        max_value=10000,
+        resolution=10000 / 255,
     ),
     # -- Shade channels ------------------------------------------------
     OutputChannelType.SHADE_POSITION_OUTSIDE: ChannelSpec(
         name="shadePositionOutside",
         min_value=0,
         max_value=100,
-        resolution=100 / 255,
+        resolution=100 / 65536,
+        siunit="percent",
+        symbol="%",
     ),
     OutputChannelType.SHADE_POSITION_INDOOR: ChannelSpec(
         name="shadePositionIndoor",
         min_value=0,
         max_value=100,
-        resolution=100 / 255,
+        resolution=100 / 65536,
+        siunit="percent",
+        symbol="%",
     ),
     OutputChannelType.SHADE_OPENING_ANGLE_OUTSIDE: ChannelSpec(
         name="shadeOpeningAngleOutside",
         min_value=0,
         max_value=100,
-        resolution=100 / 255,
+        resolution=100 / 65536,
+        siunit="percent",
+        symbol="%",
     ),
     OutputChannelType.SHADE_OPENING_ANGLE_INDOOR: ChannelSpec(
         name="shadeOpeningAngleIndoor",
         min_value=0,
         max_value=100,
-        resolution=100 / 255,
+        resolution=100 / 65536,
+        siunit="percent",
+        symbol="%",
     ),
     OutputChannelType.TRANSPARENCY: ChannelSpec(
         name="transparency",
         min_value=0,
         max_value=100,
         resolution=100 / 255,
+        siunit="percent",
+        symbol="%",
     ),
     # -- Climate channels ----------------------------------------------
     OutputChannelType.HEATING_POWER: ChannelSpec(
@@ -191,18 +234,24 @@ CHANNEL_SPECS: dict[OutputChannelType, ChannelSpec] = {
         min_value=0,
         max_value=100,
         resolution=100 / 255,
+        siunit="percent",
+        symbol="%",
     ),
     OutputChannelType.COOLING_CAPACITY: ChannelSpec(
         name="coolingCapacity",
         min_value=0,
         max_value=100,
         resolution=100 / 255,
+        siunit="percent",
+        symbol="%",
     ),
     OutputChannelType.AIR_FLOW_INTENSITY: ChannelSpec(
         name="airFlowIntensity",
         min_value=0,
         max_value=100,
         resolution=100 / 255,
+        siunit="percent",
+        symbol="%",
     ),
     OutputChannelType.AIR_FLOW_DIRECTION: ChannelSpec(
         name="airFlowDirection",
@@ -215,12 +264,16 @@ CHANNEL_SPECS: dict[OutputChannelType, ChannelSpec] = {
         min_value=0,
         max_value=100,
         resolution=100 / 255,
+        siunit="percent",
+        symbol="%",
     ),
     OutputChannelType.AIR_LOUVER_POSITION: ChannelSpec(
         name="airLouverPosition",
         min_value=0,
         max_value=100,
         resolution=100 / 255,
+        siunit="percent",
+        symbol="%",
     ),
     OutputChannelType.AIR_LOUVER_AUTO: ChannelSpec(
         name="airLouverAuto",
@@ -240,6 +293,8 @@ CHANNEL_SPECS: dict[OutputChannelType, ChannelSpec] = {
         min_value=0,
         max_value=100,
         resolution=100 / 255,
+        siunit="percent",
+        symbol="%",
     ),
     # -- Misc channels -------------------------------------------------
     OutputChannelType.WATER_TEMPERATURE: ChannelSpec(
@@ -265,6 +320,8 @@ CHANNEL_SPECS: dict[OutputChannelType, ChannelSpec] = {
         min_value=0,
         max_value=100,
         resolution=100 / 255,
+        siunit="percent",
+        symbol="%",
     ),
     # -- Video channels ------------------------------------------------
     OutputChannelType.VIDEO_STATION: ChannelSpec(
@@ -626,7 +683,8 @@ class OutputChannel:
         :attr:`name` inside the ``channelDescriptions`` property sub-tree
         (§4.9.1).  Keys match the vDC API property names.
         """
-        return {
+        spec = get_channel_spec(self._channel_type)
+        props: dict[str, Any] = {
             "name": self._name,
             "channelType": int(self._channel_type),
             "dsIndex": self._ds_index,
@@ -634,6 +692,11 @@ class OutputChannel:
             "max": self._max_value,
             "resolution": self._resolution,
         }
+        if spec is not None and spec.siunit:
+            props["siunit"] = spec.siunit
+        if spec is not None and spec.symbol:
+            props["symbol"] = spec.symbol
+        return props
 
     def get_settings_properties(self) -> dict[str, Any]:
         """Return this channel's ``channelSettings`` value dict.

--- a/src/pydsvdcapi/output_channel.py
+++ b/src/pydsvdcapi/output_channel.py
@@ -59,7 +59,7 @@ Property exposure
 
 Three property sub-trees at the vdSD level (§4.1.3), each represented
 as a **single** ``PropertyElement`` whose children are keyed by the
-channel's **name** (e.g. ``"brightness"``, ``"colortemp"``):
+channel's **dsIndex** string (e.g. ``"0"``, ``"1"``):
 
 * **channelDescriptions** — read-only metadata (name, channelType,
   dsIndex, min, max, resolution).
@@ -70,11 +70,16 @@ channel's **name** (e.g. ``"brightness"``, ``"colortemp"``):
 
 .. important::
 
-   dSS identifies channels by their **name**, not by their numeric
-   ``dsIndex``.  All three property sub-trees must therefore use the
-   channel name as the element key.  The ``setOutputChannelValue``
-   notification from dSS also carries the name in the ``channelId``
-   field (API v3 onwards).
+   All three property sub-trees (``channelDescriptions``,
+   ``channelSettings``, ``channelStates``) and push notifications use
+   the channel's **dsIndex** as the element key (e.g. ``"0"``, ``"1"``),
+   matching the p44vdc wire format.  The channel name is carried as the
+   ``name`` field *inside* each element.
+
+   The ``setOutputChannelValue`` notification from dSS carries the
+   channel name in the ``channelId`` field (API v3+), which is resolved
+   by name-matching in :class:`~pydsvdcapi.vdc_host.VdcHost` — this
+   is independent of the property key format.
 
 Persistence
 ~~~~~~~~~~~
@@ -680,8 +685,9 @@ class OutputChannel:
         """Return this channel's ``channelDescriptions`` value dict.
 
         The returned dict is used as the *value* of the element keyed by
-        :attr:`name` inside the ``channelDescriptions`` property sub-tree
-        (§4.9.1).  Keys match the vDC API property names.
+        :attr:`dsIndex` (the channel's integer index as a string) inside the
+        ``channelDescriptions`` property sub-tree (§4.9.1).  Keys match the
+        vDC API property names.
         """
         spec = get_channel_spec(self._channel_type)
         props: dict[str, Any] = {
@@ -702,8 +708,9 @@ class OutputChannel:
         """Return this channel's ``channelSettings`` value dict.
 
         The returned dict is used as the *value* of the element keyed by
-        :attr:`name` inside the ``channelSettings`` property sub-tree
-        (§4.9.2).  Currently no per-channel settings are defined.
+        :attr:`dsIndex` (the channel's integer index as a string) inside the
+        ``channelSettings`` property sub-tree (§4.9.2).  Currently no
+        per-channel settings are defined.
         """
         return {}
 
@@ -711,8 +718,9 @@ class OutputChannel:
         """Return this channel's ``channelStates`` value dict.
 
         The returned dict is used as the *value* of the element keyed by
-        :attr:`name` inside the ``channelStates`` property sub-tree
-        (§4.9.3).  Keys match the vDC API property names.
+        :attr:`dsIndex` (the channel's integer index as a string) inside the
+        ``channelStates`` property sub-tree (§4.9.3).  Keys match the vDC API
+        property names.
         """
         return {
             "value": self._value,  # may be None (NULL)

--- a/tests/test_device_template.py
+++ b/tests/test_device_template.py
@@ -405,16 +405,16 @@ class TestDeviceGetTemplateTree:
 
 
 class TestDeviceAnnounceCallbackGuard:
-    def test_no_guard_for_non_template_device(self):
+    async def test_no_guard_for_non_template_device(self):
         """Device created directly (not via template) must announce freely."""
         host = _make_host()
         vdc = _make_vdc(host)
         device = _make_simple_device(vdc)
         session = _make_session()
         # Should not raise — no _required_callbacks set
-        asyncio.get_event_loop().run_until_complete(device.announce(session))
+        await device.announce(session)
 
-    def test_raises_when_callbacks_missing(self):
+    async def test_raises_when_callbacks_missing(self):
         host = _make_host()
         vdc = _make_vdc(host)
         device = _make_simple_device(vdc)
@@ -422,10 +422,10 @@ class TestDeviceAnnounceCallbackGuard:
         device._required_callbacks = {"vdsds[0].on_identify": None}
         session = _make_session()
         with pytest.raises(AnnouncementNotReadyError) as exc_info:
-            asyncio.get_event_loop().run_until_complete(device.announce(session))
+            await device.announce(session)
         assert "vdsds[0].on_identify" in exc_info.value.missing_callbacks
 
-    def test_no_raise_when_callback_is_set(self):
+    async def test_no_raise_when_callback_is_set(self):
         host = _make_host()
         vdc = _make_vdc(host)
         device = _make_simple_device(vdc)
@@ -434,19 +434,19 @@ class TestDeviceAnnounceCallbackGuard:
         vdsd.on_identify = lambda v: None
         session = _make_session()
         # Should not raise
-        asyncio.get_event_loop().run_until_complete(device.announce(session))
+        await device.announce(session)
 
-    def test_raises_when_output_callback_missing(self):
+    async def test_raises_when_output_callback_missing(self):
         host = _make_host()
         vdc = _make_vdc(host)
         device = _make_output_device(vdc)
         device._required_callbacks = {"vdsds[0].output.on_channel_applied": None}
         session = _make_session()
         with pytest.raises(AnnouncementNotReadyError) as exc_info:
-            asyncio.get_event_loop().run_until_complete(device.announce(session))
+            await device.announce(session)
         assert "vdsds[0].output.on_channel_applied" in exc_info.value.missing_callbacks
 
-    def test_no_raise_when_output_callback_set(self):
+    async def test_no_raise_when_output_callback_set(self):
         host = _make_host()
         vdc = _make_vdc(host)
         device = _make_output_device(vdc)
@@ -454,7 +454,7 @@ class TestDeviceAnnounceCallbackGuard:
         vdsd = list(device.vdsds.values())[0]
         vdsd._output.on_channel_applied = lambda o, u: None
         session = _make_session()
-        asyncio.get_event_loop().run_until_complete(device.announce(session))
+        await device.announce(session)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -634,6 +634,41 @@ class TestOutputStateProperties:
         # Assert: falls back to default
         assert out.get_state_properties()["transitionTime"] == 0.0
 
+    def test_output_state_includes_moving_state(self):
+        """movingState defaults to 0 (idle)."""
+        host, vdc, device, vdsd = _make_stack()
+        out = _make_output(vdsd)
+        state = out.get_state_properties()
+        assert "movingState" in state
+        assert state["movingState"] == 0
+
+    def test_apply_state_stores_moving_state(self):
+        host, vdc, device, vdsd = _make_stack()
+        out = _make_output(vdsd)
+        out.apply_state({"movingState": 1})
+        assert out.get_state_properties()["movingState"] == 1
+
+    def test_moving_state_property_setter(self):
+        host, vdc, device, vdsd = _make_stack()
+        out = _make_output(vdsd)
+        out.moving_state = -1
+        assert out.get_state_properties()["movingState"] == -1
+
+    def test_moving_state_not_in_property_tree(self):
+        host, vdc, device, vdsd = _make_stack()
+        out = _make_output(vdsd)
+        out.moving_state = 1
+        tree = out.get_property_tree()
+        # movingState must not appear in the property tree (it is volatile)
+        assert "movingState" not in tree
+
+    def test_apply_state_moving_state_none_falls_back_to_zero(self):
+        host, vdc, device, vdsd = _make_stack()
+        out = _make_output(vdsd)
+        out.apply_state({"movingState": 1})
+        out.apply_state({"movingState": None})
+        assert out.get_state_properties()["movingState"] == 0
+
 
 # ===========================================================================
 # apply_settings
@@ -776,7 +811,7 @@ class TestOutputApplySettings:
         out = _make_output(vdsd)
         out.apply_settings({"mode": 2, "someUnknownKey": 99})
         s = out.get_settings_properties()
-        assert s["mode"] == 2          # known field handled normally
+        assert s["mode"] == 2  # known field handled normally
         assert s["someUnknownKey"] == 99  # unknown field stored
 
     def test_extra_settings_persisted_in_property_tree(self):
@@ -958,11 +993,13 @@ class TestOutputPropertyTree:
         out.local_priority = True
         out.error = OutputError.SHORT_CIRCUIT
         out.transition_time = 1.5
+        out.moving_state = 1
         tree = out.get_property_tree()
 
         assert "localPriority" not in tree
         assert "error" not in tree
         assert "transitionTime" not in tree
+        assert "movingState" not in tree
 
     def test_round_trip(self):
         """Serialize → _apply_state → verify all properties match."""

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -753,11 +753,70 @@ class TestOutputApplySettings:
         out.apply_settings({"heatingSystemType": None})
         assert out.heating_system_type is None
 
-    def test_apply_unknown_keys_ignored(self):
+    def test_apply_unknown_keys_now_stored(self):
+        """Unknown keys are now stored (not silently dropped) — known key still applied."""
         host, vdc, device, vdsd = _make_stack()
         out = _make_output(vdsd)
         out.apply_settings({"unknownKey": 42, "mode": 1})
         assert out.mode == OutputMode.BINARY
+        # Unknown key must now be accessible via get_settings_properties.
+        s = out.get_settings_properties()
+        assert s["unknownKey"] == 42
+
+    def test_apply_settings_stores_unknown_key(self):
+        host, vdc, device, vdsd = _make_stack()
+        out = _make_output(vdsd)
+        out.apply_settings({"someUnknownKey": 42.0, "anotherKey": "hello"})
+        s = out.get_settings_properties()
+        assert s["someUnknownKey"] == 42.0
+        assert s["anotherKey"] == "hello"
+
+    def test_apply_settings_unknown_key_does_not_shadow_known(self):
+        host, vdc, device, vdsd = _make_stack()
+        out = _make_output(vdsd)
+        out.apply_settings({"mode": 2, "someUnknownKey": 99})
+        s = out.get_settings_properties()
+        assert s["mode"] == 2          # known field handled normally
+        assert s["someUnknownKey"] == 99  # unknown field stored
+
+    def test_extra_settings_persisted_in_property_tree(self):
+        host, vdc, device, vdsd = _make_stack()
+        out = _make_output(vdsd)
+        out.apply_settings({"customField": "value"})
+        tree = out.get_property_tree()
+        assert tree.get("customField") == "value"
+
+    def test_extra_settings_absent_when_empty(self):
+        """No extra keys appear in settings when nothing unknown was stored."""
+        host, vdc, device, vdsd = _make_stack()
+        out = _make_output(vdsd)
+        s = out.get_settings_properties()
+        assert "someUnknownKey" not in s
+
+    def test_extra_settings_cumulative_across_calls(self):
+        """Successive apply_settings calls accumulate extra settings."""
+        host, vdc, device, vdsd = _make_stack()
+        out = _make_output(vdsd)
+        out.apply_settings({"firstKey": 1})
+        out.apply_settings({"secondKey": 2})
+        s = out.get_settings_properties()
+        assert s["firstKey"] == 1
+        assert s["secondKey"] == 2
+
+    def test_extra_settings_round_trip(self):
+        """Extra settings survive a get_property_tree / _apply_state round-trip."""
+        host, vdc, device, vdsd = _make_stack()
+        out = _make_output(vdsd)
+        out.apply_settings({"customField": "value", "numericExtra": 3.14})
+        tree = out.get_property_tree()
+
+        _, _, _, vdsd2 = _make_stack()
+        out2 = _make_output(vdsd2)
+        out2._apply_state(tree)
+
+        s = out2.get_settings_properties()
+        assert s["customField"] == "value"
+        assert s["numericExtra"] == pytest.approx(3.14)
 
     def test_apply_empty_dict(self):
         host, vdc, device, vdsd = _make_stack()

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -603,6 +603,37 @@ class TestOutputStateProperties:
         assert state["localPriority"] is True
         assert state["error"] == int(OutputError.SHORT_CIRCUIT)
 
+    def test_output_state_includes_transition_time(self):
+        host, vdc, device, vdsd = _make_stack()
+        out = _make_output(vdsd)
+        state = out.get_state_properties()
+        assert "transitionTime" in state
+        assert isinstance(state["transitionTime"], float)
+        assert state["transitionTime"] == 0.0  # default
+
+    def test_apply_state_stores_transition_time(self):
+        host, vdc, device, vdsd = _make_stack()
+        out = _make_output(vdsd)
+        out.apply_state({"transitionTime": 0.5})
+        assert out.get_state_properties()["transitionTime"] == 0.5
+
+    def test_transition_time_property_setter(self):
+        host, vdc, device, vdsd = _make_stack()
+        out = _make_output(vdsd)
+        out.transition_time = 2.5
+        assert out.get_state_properties()["transitionTime"] == 2.5
+
+    def test_apply_state_transition_time_none_falls_back_to_zero(self):
+        """Applying None value for transitionTime falls back to default."""
+        host, vdc, device, vdsd = _make_stack()
+        out = _make_output(vdsd)
+        # Arrange: set to non-zero first
+        out.apply_state({"transitionTime": 1.5})
+        # Act: apply None value
+        out.apply_state({"transitionTime": None})
+        # Assert: falls back to default
+        assert out.get_state_properties()["transitionTime"] == 0.0
+
 
 # ===========================================================================
 # apply_settings
@@ -867,10 +898,12 @@ class TestOutputPropertyTree:
         out = _make_output(vdsd)
         out.local_priority = True
         out.error = OutputError.SHORT_CIRCUIT
+        out.transition_time = 1.5
         tree = out.get_property_tree()
 
         assert "localPriority" not in tree
         assert "error" not in tree
+        assert "transitionTime" not in tree
 
     def test_round_trip(self):
         """Serialize → _apply_state → verify all properties match."""

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -3212,3 +3212,170 @@ class TestMatchesZoneAndGroup:
         out = _make_output(vdsd, function=OutputFunction.DIMMER)
         out.active_group = int(ColorGroup.YELLOW)
         assert host._matches_zone_and_group(vdsd, out, 42, 0) is True
+
+
+# ===========================================================================
+# Shadow motor timing fields
+# ===========================================================================
+
+
+class TestShadowTimingFields:
+    """Tests for shadow motor timing fields in outputSettings."""
+
+    def test_shadow_timing_fields_in_settings(self):
+        """Shadow timing fields appear in outputSettings when set."""
+        host, vdc, device, vdsd = _make_stack()
+        out = _make_output(vdsd)
+        out._open_time = 60.0
+        out._close_time = 55.0
+        out._angle_open_time = 1.5
+        out._angle_close_time = 1.5
+        out._stop_delay_time = 0.5
+        s = out.get_settings_properties()
+        assert s["openTime"] == 60.0
+        assert s["closeTime"] == 55.0
+        assert s["angleOpenTime"] == 1.5
+        assert s["angleCloseTime"] == 1.5
+        assert s["stopDelayTime"] == 0.5
+
+    def test_shadow_timing_absent_when_not_set(self):
+        """Shadow timing fields are absent when not configured."""
+        host, vdc, device, vdsd = _make_stack()
+        out = _make_output(vdsd)
+        s = out.get_settings_properties()
+        assert "openTime" not in s
+        assert "closeTime" not in s
+        assert "angleOpenTime" not in s
+        assert "angleCloseTime" not in s
+        assert "stopDelayTime" not in s
+
+    def test_apply_settings_stores_shadow_timing(self):
+        """apply_settings stores shadow timing values correctly."""
+        host, vdc, device, vdsd = _make_stack()
+        out = _make_output(vdsd)
+        out.apply_settings(
+            {
+                "openTime": 45.0,
+                "closeTime": 40.0,
+                "angleOpenTime": 2.0,
+                "angleCloseTime": 2.0,
+                "stopDelayTime": 0.3,
+            }
+        )
+        s = out.get_settings_properties()
+        assert s["openTime"] == 45.0
+        assert s["closeTime"] == 40.0
+        assert s["angleOpenTime"] == 2.0
+        assert s["angleCloseTime"] == 2.0
+        assert s["stopDelayTime"] == 0.3
+
+    def test_shadow_timing_init_params(self):
+        """Shadow timing fields can be set at construction time."""
+        host, vdc, device, vdsd = _make_stack()
+        out = Output(
+            vdsd=vdsd,
+            function=OutputFunction.POSITIONAL,
+            name="Blind Motor",
+            default_group=8,
+            active_group=8,
+            groups={8},
+            open_time=60.0,
+            close_time=55.0,
+            angle_open_time=1.5,
+            angle_close_time=1.5,
+            stop_delay_time=0.5,
+        )
+        assert out.open_time == 60.0
+        assert out.close_time == 55.0
+        assert out.angle_open_time == 1.5
+        assert out.angle_close_time == 1.5
+        assert out.stop_delay_time == 0.5
+
+    def test_shadow_timing_default_none(self):
+        """Shadow timing fields default to None."""
+        host, vdc, device, vdsd = _make_stack()
+        out = _make_output(vdsd)
+        assert out.open_time is None
+        assert out.close_time is None
+        assert out.angle_open_time is None
+        assert out.angle_close_time is None
+        assert out.stop_delay_time is None
+
+    def test_shadow_timing_persisted_in_tree(self):
+        """Shadow timing fields appear in get_property_tree when set."""
+        host, vdc, device, vdsd = _make_stack()
+        out = Output(
+            vdsd=vdsd,
+            function=OutputFunction.POSITIONAL,
+            name="Blind",
+            default_group=8,
+            active_group=8,
+            groups={8},
+            open_time=60.0,
+            close_time=55.0,
+            angle_open_time=1.5,
+            angle_close_time=1.5,
+            stop_delay_time=0.5,
+        )
+        tree = out.get_property_tree()
+        assert tree["openTime"] == 60.0
+        assert tree["closeTime"] == 55.0
+        assert tree["angleOpenTime"] == 1.5
+        assert tree["angleCloseTime"] == 1.5
+        assert tree["stopDelayTime"] == 0.5
+
+    def test_shadow_timing_absent_from_tree_when_not_set(self):
+        """Shadow timing fields are absent from property tree when None."""
+        host, vdc, device, vdsd = _make_stack()
+        out = _make_output(vdsd)
+        tree = out.get_property_tree()
+        assert "openTime" not in tree
+        assert "closeTime" not in tree
+        assert "angleOpenTime" not in tree
+        assert "angleCloseTime" not in tree
+        assert "stopDelayTime" not in tree
+
+    def test_shadow_timing_round_trip(self):
+        """Shadow timing survives get_property_tree / _apply_state round-trip."""
+        host, vdc, device, vdsd = _make_stack()
+        original = Output(
+            vdsd=vdsd,
+            function=OutputFunction.POSITIONAL,
+            name="Blind",
+            default_group=8,
+            active_group=8,
+            groups={8},
+            open_time=60.0,
+            close_time=55.0,
+            angle_open_time=1.5,
+            angle_close_time=1.5,
+            stop_delay_time=0.5,
+        )
+        tree = original.get_property_tree()
+
+        restored = Output(
+            vdsd=vdsd, name="restored", default_group=0, active_group=0, groups=set()
+        )
+        restored._apply_state(tree)
+
+        assert restored.open_time == 60.0
+        assert restored.close_time == 55.0
+        assert restored.angle_open_time == 1.5
+        assert restored.angle_close_time == 1.5
+        assert restored.stop_delay_time == 0.5
+
+    def test_apply_settings_none_resets_shadow_timing(self):
+        """apply_settings with None resets shadow timing fields."""
+        host, vdc, device, vdsd = _make_stack()
+        out = Output(
+            vdsd=vdsd,
+            function=OutputFunction.POSITIONAL,
+            name="Blind",
+            default_group=8,
+            active_group=8,
+            groups={8},
+            open_time=60.0,
+        )
+        out.apply_settings({"openTime": None})
+        assert out.open_time is None
+        assert "openTime" not in out.get_settings_properties()

--- a/tests/test_output_channel.py
+++ b/tests/test_output_channel.py
@@ -623,9 +623,7 @@ class TestOutputChannelProperties:
         assert "0" in desc
         assert "1" in desc
         assert desc["0"]["channelType"] == int(OutputChannelType.BRIGHTNESS)
-        assert desc["1"]["channelType"] == int(
-            OutputChannelType.COLOR_TEMPERATURE
-        )
+        assert desc["1"]["channelType"] == int(OutputChannelType.COLOR_TEMPERATURE)
         # Channel name is still present inside each element.
         assert desc["0"]["name"] == "brightness"
         assert desc["1"]["name"] == "colortemp"
@@ -1450,8 +1448,8 @@ class TestChannelContainerKeyedByDsIndex:
         out = self._make_dimmer()
         desc = out.get_channel_descriptions()
         ch = list(out.channels.values())[0]
-        assert str(ch.ds_index) in desc          # e.g. "0"
-        assert ch.name not in desc               # "brightness" must NOT be a key
+        assert str(ch.ds_index) in desc  # e.g. "0"
+        assert ch.name not in desc  # "brightness" must NOT be a key
 
     def test_channel_settings_keyed_by_dsindex(self):
         """channelSettings must be keyed by dsIndex string, not channel name."""
@@ -1497,5 +1495,5 @@ class TestChannelContainerKeyedByDsIndex:
         sent_msg = session.send_notification.call_args[0][0]
         props = elements_to_dict(sent_msg.vdc_send_push_notification.changedproperties)
         assert "channelStates" in props
-        assert str(ch.ds_index) in props["channelStates"]   # "0"
-        assert ch.name not in props["channelStates"]         # not "brightness"
+        assert str(ch.ds_index) in props["channelStates"]  # "0"
+        assert ch.name not in props["channelStates"]  # not "brightness"

--- a/tests/test_output_channel.py
+++ b/tests/test_output_channel.py
@@ -1317,6 +1317,82 @@ class TestEdgeCases:
 
 
 # ===========================================================================
+# siunit / symbol in channel descriptions
+# ===========================================================================
+
+
+class TestChannelDescriptionSiunitSymbol:
+    """Tests for siunit and symbol fields in channelDescriptions."""
+
+    def test_channel_description_includes_siunit_and_symbol(self):
+        _, _, _, vdsd = _make_stack()
+        out = _make_output(vdsd, function=OutputFunction.DIMMER)
+        ch = out.get_channel(0)
+        desc = ch.get_description_properties()
+        assert "siunit" in desc
+        assert "symbol" in desc
+        assert desc["siunit"] == "percent"
+        assert desc["symbol"] == "%"
+
+    def test_shade_channel_description_includes_siunit_percent(self):
+        _, _, _, vdsd = _make_stack()
+        out = _make_output(vdsd, function=OutputFunction.POSITIONAL)
+        ch = out.add_channel(OutputChannelType.SHADE_POSITION_OUTSIDE, ds_index=0)
+        desc = ch.get_description_properties()
+        assert desc["siunit"] == "percent"
+        assert desc["symbol"] == "%"
+
+    def test_colortemp_channel_siunit(self):
+        _, _, _, vdsd = _make_stack()
+        out = _make_output(vdsd, function=OutputFunction.DIMMER_COLOR_TEMP)
+        ch = out.get_channel_by_type(OutputChannelType.COLOR_TEMPERATURE)
+        desc = ch.get_description_properties()
+        assert desc["siunit"] == "reciprocal megakelvin"
+        assert desc["symbol"] == "mired"
+
+    def test_hue_channel_siunit(self):
+        _, _, _, vdsd = _make_stack()
+        out = _make_output(vdsd, function=OutputFunction.FULL_COLOR_DIMMER)
+        ch = out.get_channel_by_type(OutputChannelType.HUE)
+        desc = ch.get_description_properties()
+        assert desc["siunit"] == "degree"
+        assert desc["symbol"] == "°"
+
+    def test_cie_x_channel_no_siunit(self):
+        _, _, _, vdsd = _make_stack()
+        out = _make_output(vdsd, function=OutputFunction.FULL_COLOR_DIMMER)
+        ch = out.get_channel_by_type(OutputChannelType.CIE_X)
+        desc = ch.get_description_properties()
+        assert "siunit" not in desc
+        assert "symbol" not in desc
+
+    def test_air_flow_direction_no_siunit(self):
+        _, _, _, vdsd = _make_stack()
+        out = _make_output(vdsd, function=OutputFunction.POSITIONAL)
+        ch = out.add_channel(OutputChannelType.AIR_FLOW_DIRECTION, ds_index=0)
+        desc = ch.get_description_properties()
+        assert "siunit" not in desc
+        assert "symbol" not in desc
+
+    def test_shade_position_resolution_16bit(self):
+        """Shade channels must use 16-bit resolution (100/65536)."""
+        spec = CHANNEL_SPECS[OutputChannelType.SHADE_POSITION_OUTSIDE]
+        assert spec.resolution == pytest.approx(100 / 65536)
+
+    def test_shade_angle_resolution_16bit(self):
+        spec = CHANNEL_SPECS[OutputChannelType.SHADE_OPENING_ANGLE_OUTSIDE]
+        assert spec.resolution == pytest.approx(100 / 65536)
+
+    def test_shade_indoor_resolution_16bit(self):
+        spec = CHANNEL_SPECS[OutputChannelType.SHADE_POSITION_INDOOR]
+        assert spec.resolution == pytest.approx(100 / 65536)
+
+    def test_shade_angle_indoor_resolution_16bit(self):
+        spec = CHANNEL_SPECS[OutputChannelType.SHADE_OPENING_ANGLE_INDOOR]
+        assert spec.resolution == pytest.approx(100 / 65536)
+
+
+# ===========================================================================
 # __init__.py exports
 # ===========================================================================
 

--- a/tests/test_output_channel.py
+++ b/tests/test_output_channel.py
@@ -619,19 +619,24 @@ class TestOutputChannelProperties:
         out = _make_output(vdsd, function=OutputFunction.DIMMER_COLOR_TEMP)
         desc = out.get_channel_descriptions()
         assert len(desc) == 2
-        assert "brightness" in desc
-        assert "colortemp" in desc
-        assert desc["brightness"]["channelType"] == int(OutputChannelType.BRIGHTNESS)
-        assert desc["colortemp"]["channelType"] == int(
+        # Keys are dsIndex strings, not channel names.
+        assert "0" in desc
+        assert "1" in desc
+        assert desc["0"]["channelType"] == int(OutputChannelType.BRIGHTNESS)
+        assert desc["1"]["channelType"] == int(
             OutputChannelType.COLOR_TEMPERATURE
         )
+        # Channel name is still present inside each element.
+        assert desc["0"]["name"] == "brightness"
+        assert desc["1"]["name"] == "colortemp"
 
     def test_channel_settings(self):
         _, _, _, vdsd = _make_stack()
         out = _make_output(vdsd, function=OutputFunction.DIMMER)
         settings = out.get_channel_settings()
         assert len(settings) == 1
-        assert settings["brightness"] == {}
+        # Key is dsIndex string "0", not "brightness".
+        assert settings["0"] == {}
 
     @pytest.mark.asyncio
     async def test_channel_states(self):
@@ -640,8 +645,9 @@ class TestOutputChannelProperties:
         ch = out.get_channel(0)
         await ch.update_value(60.0)
         states = out.get_channel_states()
-        assert states["brightness"]["value"] == 60.0
-        assert states["brightness"]["age"] is not None
+        # Key is dsIndex string "0", not "brightness".
+        assert states["0"]["value"] == 60.0
+        assert states["0"]["age"] is not None
 
 
 # ===========================================================================
@@ -966,8 +972,9 @@ class TestVdsdChannelProperties:
 
         props = vdsd.get_properties()
         assert "channelDescriptions" in props
-        assert "brightness" in props["channelDescriptions"]
-        assert props["channelDescriptions"]["brightness"]["name"] == "brightness"
+        # Keys are dsIndex strings, not channel names.
+        assert "0" in props["channelDescriptions"]
+        assert props["channelDescriptions"]["0"]["name"] == "brightness"
 
     def test_properties_include_channel_states(self):
         _, _, _, vdsd = _make_stack()
@@ -976,8 +983,9 @@ class TestVdsdChannelProperties:
 
         props = vdsd.get_properties()
         assert "channelStates" in props
-        assert "brightness" in props["channelStates"]
-        assert props["channelStates"]["brightness"]["value"] is None
+        # Key is dsIndex string "0", not "brightness".
+        assert "0" in props["channelStates"]
+        assert props["channelStates"]["0"]["value"] is None
 
     def test_properties_include_channel_settings(self):
         _, _, _, vdsd = _make_stack()
@@ -986,7 +994,8 @@ class TestVdsdChannelProperties:
 
         props = vdsd.get_properties()
         assert "channelSettings" in props
-        assert "brightness" in props["channelSettings"]
+        # Key is dsIndex string "0", not "brightness".
+        assert "0" in props["channelSettings"]
 
     def test_no_channels_no_properties(self):
         _, _, _, vdsd = _make_stack()
@@ -1420,3 +1429,73 @@ class TestExports:
         from pydsvdcapi import FUNCTION_CHANNELS
 
         assert OutputFunction.DIMMER in FUNCTION_CHANNELS
+
+
+# ===========================================================================
+# dsIndex-keyed channel container tests
+# ===========================================================================
+
+
+class TestChannelContainerKeyedByDsIndex:
+    """channelDescriptions/channelSettings/channelStates must be keyed by
+    str(dsIndex), not channel name, to match the p44vdc wire format."""
+
+    def _make_dimmer(self):
+        _, _, _, vdsd = _make_stack()
+        out = _make_output(vdsd, function=OutputFunction.DIMMER)
+        return out
+
+    def test_channel_descriptions_keyed_by_dsindex(self):
+        """channelDescriptions must be keyed by dsIndex string, not channel name."""
+        out = self._make_dimmer()
+        desc = out.get_channel_descriptions()
+        ch = list(out.channels.values())[0]
+        assert str(ch.ds_index) in desc          # e.g. "0"
+        assert ch.name not in desc               # "brightness" must NOT be a key
+
+    def test_channel_settings_keyed_by_dsindex(self):
+        """channelSettings must be keyed by dsIndex string, not channel name."""
+        out = self._make_dimmer()
+        settings = out.get_channel_settings()
+        ch = list(out.channels.values())[0]
+        assert str(ch.ds_index) in settings
+        assert ch.name not in settings
+
+    def test_channel_states_keyed_by_dsindex(self):
+        """channelStates must be keyed by dsIndex string, not channel name."""
+        out = self._make_dimmer()
+        states = out.get_channel_states()
+        ch = list(out.channels.values())[0]
+        assert str(ch.ds_index) in states
+        assert ch.name not in states
+
+    def test_multi_channel_dsindex_keys(self):
+        """Multi-channel output keys should be '0', '1', … not names."""
+        _, _, _, vdsd = _make_stack()
+        out = _make_output(vdsd, function=OutputFunction.DIMMER_COLOR_TEMP)
+        desc = out.get_channel_descriptions()
+        assert "0" in desc
+        assert "1" in desc
+        assert "brightness" not in desc
+        assert "colortemp" not in desc
+
+    @pytest.mark.asyncio
+    async def test_push_notification_keyed_by_dsindex(self):
+        """Push notification channelStates must use dsIndex string as key."""
+        from pydsvdcapi.property_handling import elements_to_dict
+
+        _, _, _, vdsd = _make_stack()
+        out = _make_output(vdsd, function=OutputFunction.DIMMER)
+        out.push_changes = True
+        session = _make_mock_session()
+        out.start_session(session)
+        vdsd.set_output(out)
+
+        ch = out.get_channel(0)
+        await ch.update_value(42.0)
+
+        sent_msg = session.send_notification.call_args[0][0]
+        props = elements_to_dict(sent_msg.vdc_send_push_notification.changedproperties)
+        assert "channelStates" in props
+        assert str(ch.ds_index) in props["channelStates"]   # "0"
+        assert ch.name not in props["channelStates"]         # not "brightness"


### PR DESCRIPTION
## Summary

Fixes six wire-format errors on grey (shade/blind) devices. Adds additional output state/settings fields for better protocol coverage.

- **CRITICAL** `siunit` and `symbol` added to all `channelDescriptions` responses — identified as the primary cause of grey-device validation errors on dSS
- **CRITICAL** Shade channel resolution corrected from 8-bit (`100/255`) to 16-bit (`100/65536`)
- **CRITICAL** All channel container keys (`channelDescriptions`, `channelSettings`, `channelStates` in GET responses and push notifications) reverted to dsIndex string keys (e.g. `"0"`, `"1"`), 
- Shadow motor timing fields added to `outputSettings`: `openTime`, `closeTime`, `angleOpenTime`, `angleCloseTime`, `stopDelayTime`
- `transitionTime` added to `outputState` 
- `movingState` added to `outputState`: `0`=idle, `1`=moving open/up, `-1`=moving closed/down
- Unknown `setProperty outputSettings` keys are now stored in `_extra_settings` and returned in future responses instead of being silently dropped

## Documentation

- `docs/vdc-api-properties.md` updated: outputState table now includes `transitionTime` and `movingState`; channel key format note corrected; `siunit`/`symbol` added to channelDescriptions table

## Test plan

- [ ] All 1499 tests pass (`pytest tests/ -q`)
- [ ] `ruff format` + `ruff check` clean
- [ ] Verify grey/shade device connects without `deviceOutputIndex:255` errors on dSS
- [ ] Verify shade position and angle channels accept values from dSS scene calls
- [ ] Verify `movingState` can be set and pushed when motor starts/stops

🤖 Generated with [Claude Code](https://claude.com/claude-code)