### PR TITLE
Release 0.9.0: settings callbacks, push_settings, channel key compat, and protocol fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,14 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Fixed
-- Channel container keys (`channelDescriptions`, `channelSettings`, `channelStates`) for `POSITIONAL` (2) output function now use the **channel name** (e.g. `"shadePositionOutside"`) as the outer key, matching the p44vdc wire format.  The vdSM builds the OPC table from the `channelType` and `dsIndex` sub-element fields — not from the outer key — so channel names are correct here.  All three multi-channel output functions (POSITIONAL, DIMMER_COLOR_TEMP, FULL_COLOR_DIMMER) now consistently use channel names as container keys.
-- Removed S2 awning workaround in `examples/example_shading.py` (`name="0"` override); the example now uses the standard `add_channel(OutputChannelType.SHADE_POSITION_OUTSIDE)` call.
+## [0.8.9] - 2026-06-15
 
 ### Added
 - `on_disconnect` callback parameter on `VdcHost.start()`: an optional async callback fired when the vdSM TCP connection is lost unexpectedly (network drop, dSS restart, etc.). Receives `(host: VdcHost, reason: Exception | None)` — `reason` is the exception that caused the disconnect, or `None` for a clean EOF / bye. The callback is **not** called when `host.stop()` initiates the disconnect.
 - `VdcSession.disconnect_reason: Exception | None` attribute — exposed after `session.run()` returns so callers can inspect what ended the session.
 - `shadeprops` and `motiontimefins` model features are no longer blocked: they have been moved from the unsupported set to the "not tested / add manually" category. Add them via `add_model_feature()` on grey shade devices that expose motor timing `outputSettings` fields.
+- `FCU_OPERATION_MODE` channel type added to `OutputChannelType` enum and `CHANNEL_SPECS`, with correct enum `values` (`off`, `heating`, `cooling`, `fanOnly`, `dry`, `auto`).
+- `COLOR_CLASS_STANDARD_CHANNEL` mapping added to `output_channel.py` — maps application group ID to the standard `OutputChannelType` for that group (e.g. group 1 → `BRIGHTNESS`, group 2 → `SHADE_POSITION_OUTSIDE`). Used for resolving channel-type key `"0"` per ds-basics §7.
+- `values` container emitted in `channelDescriptions` for all enum/discrete channels: `AIR_FLOW_DIRECTION`, `AIR_LOUVER_AUTO`, `AIR_FLOW_AUTO`, `POWER_STATE`, `FCU_OPERATION_MODE`. String keys, string values (e.g. `{"0": "off", "1": "on"}`).
+- `OutputChannel` and `Output.add_channel()` now accept `siunit`, `symbol`, and `enum_values` parameters for fully custom channel types. For predefined types the spec is always authoritative; for device-specific channel types these parameters control what is emitted in `channelDescriptions` and what is persisted to YAML.
+- `_ChannelCompatDict` backward-compatibility layer: `getProperty` requests for `channelDescriptions`, `channelSettings`, and `channelStates` now resolve numeric keys (channel type decimal strings such as `"1"`, and the special `"0"` alias for the primary channel) in addition to the canonical channel name keys, covering API v2 and legacy lookup paths.
+
+### Fixed
+- Channel container keys (`channelDescriptions`, `channelSettings`, `channelStates`) for **all** output functions now use the **channel name string** (e.g. `"shadePositionOutside"`, `"brightness"`) as the outer key, matching p44vdc API v3+ wire format. Includes `POSITIONAL`, `DIMMER_COLOR_TEMP`, and `FULL_COLOR_DIMMER`. Numeric key backward-compatibility is handled transparently via `_ChannelCompatDict`.
+- Removed S2 awning workaround in `examples/example_shading.py` (`name="0"` override); the example now uses the standard `add_channel(OutputChannelType.SHADE_POSITION_OUTSIDE)` call.
+- `modelFeatures` property now emitted in canonical `ModelFeatureId` enum order (from `modelconst.h`) instead of alphabetical order, matching p44vdc.
+- `movingState` removed from `outputState` — it was not part of the vDC API spec and was never emitted by p44vdc.
+- `waterFlow` channel name corrected (`WATER_FLOW_RATE` spec name was missing; now `"waterFlow"`).
+- `outputSettings` shadow timing fields (`openTime`, `closeTime`, `angleOpenTime`, `angleCloseTime`, `stopDelayTime`) are now correctly gated on `primaryGroup == 2` (shade/blind devices), not emitted for other device classes.
+- `outputSettings` light-specific fields (`minBrightness`, `dimTimeUp`, `dimTimeDown`, `dimTimeUpAlt1`, `dimTimeDownAlt1`, `dimTimeUpAlt2`, `dimTimeDownAlt2`) are correctly gated on `primaryGroup == 1`.
+- `outputSettings` climate fields (`heatingSystemCapability`, `heatingSystemType`) are correctly gated on `primaryGroup == 3`.
 
 ## [0.8.8] - 2026-05-30
 
@@ -126,6 +139,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `DsUid` — dSUID encoding/decoding with multiple creation strategies.
 - Property handling helpers (`build_get_property_response`, etc.).
 
+[0.8.9]: https://github.com/KarlKiel/pyDSvDCAPI/compare/v0.8.8...v0.8.9
 [0.8.8]: https://github.com/KarlKiel/pyDSvDCAPI/compare/v0.8.7...v0.8.8
 [0.8.7]: https://github.com/KarlKiel/pyDSvDCAPI/compare/v0.8.6...v0.8.7
 [0.8.6]: https://github.com/KarlKiel/pyDSvDCAPI/compare/v0.8.4...v0.8.6

--- a/docs/p44vdc-comparison.md
+++ b/docs/p44vdc-comparison.md
@@ -20,6 +20,8 @@ Sources consulted:
 
 All comparisons are based on the property-tree structure as seen in `VDSM_REQUEST_GET_PROPERTY` responses and `VDC_SEND_PUSH_NOTIFICATION` messages.
 
+Last updated: 2026-06-15 (branch `Prepare-for-release-0.8.6`)
+
 ---
 
 ## 1. `outputDescription`
@@ -38,30 +40,29 @@ Fields returned (from `outputDescriptionProperties` static array in `outputbehav
 
 **Not present in p44vdc `outputDescription`**: `name`, `defaultGroup`, `activeCoolingMode`.
 
-### pydsvdcapi
+### pydsvdcapi (current)
 
-From `output.py` `get_description_properties()` (line 1492–1508):
+From `output.py` `get_description_properties()`:
 
 | Field name | Type | Notes |
 |---|---|---|
 | `function` | int | OutputFunction enum value |
 | `outputUsage` | int | OutputUsage enum value |
-| `name` | str | always included |
-| `defaultGroup` | int | always included |
 | `variableRamp` | bool | |
-| `maxPower` | double | only when not None |
-| `activeCoolingMode` | bool | only when not None |
+| `maxPower` | double | always present; `-1.0` when no value given |
+| `name` | str | **optional** — only when explicitly set |
+| `defaultGroup` | int | **optional** — only when explicitly set |
+| `activeCoolingMode` | bool | **optional** — only when explicitly set |
 
 ### Differences
 
 | Field | p44vdc | pydsvdcapi | Severity |
 |---|---|---|---|
-| `name` | NOT present in `outputDescription` | ALWAYS present | WARN — dSS may ignore; no known error impact for output description |
-| `defaultGroup` | NOT present in `outputDescription` | ALWAYS present | WARN — dSS may ignore; no known error impact |
-| `activeCoolingMode` | NOT present in p44vdc source | Present when set | INFO — p44vdc extension pydsvdcapi borrowed, not in p44vdc core |
-| `x-p44-recommendedTransitionTime` | Present (p44 extension) | NOT present | INFO — p44-specific extension, not required by spec |
-
-**Assessment**: The extra fields pydsvdcapi sends (`name`, `defaultGroup`) are not in the p44vdc model but appear to be harmless — the vdSM ignores unknown fields in `outputDescription`. These fields are not the cause of grey-device errors.
+| `name` | NOT in `outputDescription` | Optional — only when set | INFO — no longer always injected; harmless when present |
+| `defaultGroup` | NOT in `outputDescription` | Optional — only when set | INFO — no longer always injected; harmless when present |
+| `activeCoolingMode` | NOT in base p44vdc | Optional — only when set | INFO — extension field, harmless |
+| `maxPower` | Present; omitted when no value | Always present (`-1.0` for "no value") | INFO — `-1.0` sentinel matches dSS expectation for "unknown" |
+| `x-p44-recommendedTransitionTime` | Present (p44 extension) | NOT present | INFO — p44-specific extension, not required |
 
 ---
 
@@ -80,44 +81,48 @@ Fields returned (from `outputSettingsProperties` in `outputbehaviour.cpp`):
 
 **Critical detail on `groups`**: In p44vdc the property system encodes `groups` as a `propflag_container` of `apivalue_bool` properties. In protobuf this means a `PropertyElement` named `"groups"` that contains child `PropertyElement`s, each child having its name = the group number (as string, e.g. `"1"`, `"2"`, `"3"`) and its value as a `v_bool`. Groups **not** in the membership have value `false`; groups **in** the membership have value `true`. The container emits ALL indices in the range 0–63 (the full bitmask width), including `false` entries.
 
-**Not present in p44vdc `outputSettings`**: `activeGroup`, `onThreshold`, `minBrightness`, `dimTimeUp`, `dimTimeDown`, `dimTimeUp/DownAlt1/2`, `heatingSystemCapability`, `heatingSystemType`.
+**Not present in p44vdc base `outputSettings`**: `activeGroup`, `onThreshold`. Light/climate/shadow-specific fields live in sub-behaviours (`LightBehaviour`, `HeatingBehaviour`, `ShadowBehaviour`).
 
-### pydsvdcapi
+**Shadow-specific fields** (from `ShadowBehaviour::accessField()`):
 
-From `output.py` `get_settings_properties()` (line 1510–1548):
+| Field | Type |
+|---|---|
+| `openTime` | `double` (seconds) |
+| `closeTime` | `double` (seconds) |
+| `angleOpenTime` | `double` (seconds) |
+| `angleCloseTime` | `double` (seconds) |
+| `stopDelayTime` | `double` (seconds) |
+
+### pydsvdcapi (current)
+
+From `output.py` `get_settings_properties()`:
 
 | Field name | Type | Notes |
 |---|---|---|
 | `mode` | int | OutputMode enum |
-| `activeGroup` | int | always present |
 | `pushChanges` | bool | |
-| `groups` | dict `{str: True}` | Only `true` entries; e.g. `{"1": True, "3": True}` |
-| `onThreshold` | double | only when not None |
-| `minBrightness` | double | only when not None |
-| `dimTimeUp/Down` + Alt1/Alt2 | int | only when not None |
-| `heatingSystemCapability` | int | only when not None |
-| `heatingSystemType` | int | only when not None |
+| `activeGroup` | int | **optional** — only when explicitly set |
+| `groups` | dict `{str: True}` | Only `true` entries emitted; e.g. `{"2": True}` |
+| `onThreshold` | double | only for `function == ON_OFF`; default `50.0` |
+| `minBrightness` | double | only when set **and** `primaryGroup == 1` (light) |
+| `dimTimeUp/Down` + Alt1/Alt2 | int | only when set and `primaryGroup == 1` |
+| `heatingSystemCapability` | int | only when set **and** `primaryGroup == 3` (climate) |
+| `heatingSystemType` | int | only when set and `primaryGroup == 3` |
+| `openTime` | double | only when set **and** `primaryGroup == 2` (shadow) |
+| `closeTime` | double | only when set and `primaryGroup == 2` |
+| `angleOpenTime` | double | only when set and `primaryGroup == 2` |
+| `angleCloseTime` | double | only when set and `primaryGroup == 2` |
+| `stopDelayTime` | double | only when set and `primaryGroup == 2` |
 
 ### Differences
 
 | Field | p44vdc | pydsvdcapi | Severity |
 |---|---|---|---|
-| `groups` encoding | Boolean container — ALL indices 0–63 emitted (true/false) | Dict with only `true` entries | **WARN** — p44vdc emits both true and false entries; pydsvdcapi only emits true entries. The vdSM reads this correctly since missing = false, but write-back via `setProperty` may behave differently. Read direction: likely OK. |
-| `activeGroup` | NOT present in `outputSettings` | Always present | WARN — extra field; not known to cause errors |
+| `groups` encoding | Boolean container — ALL indices 0–63 emitted (true/false) | Only `true` entries emitted | INFO — vdSM treats missing entries as `false`; functionally equivalent for reading |
+| `activeGroup` | NOT in base `outputSettings` | Optional — only when set | INFO — extra field; not known to cause errors |
 | `x-p44-bridgePushInterval` | Present (p44 extension) | NOT present | INFO — p44 extension only |
-| Dimming/climate fields | NOT in base outputbehaviour (may be in sub-behaviour) | Present when set | INFO — sub-behaviour fields; may be in LightBehaviour for p44vdc |
-
-**Note on shadow devices**: For shadow/shade devices in p44vdc, `outputSettings` is handled by `ShadowBehaviour` and **adds** extra fields:
-
-| Field | p44vdc (ShadowBehaviour) | pydsvdcapi | Severity |
-|---|---|---|---|
-| `openTime` | `double` (seconds) — in `outputSettings` | NOT present | **WARN** — shadow-specific motor timing; if dSS sends this, pydsvdcapi ignores it |
-| `closeTime` | `double` (seconds) — in `outputSettings` | NOT present | WARN |
-| `angleOpenTime` | `double` (seconds) — in `outputSettings` | NOT present | WARN |
-| `angleCloseTime` | `double` (seconds) — in `outputSettings` | NOT present | WARN |
-| `stopDelayTime` | `double` (seconds) — in `outputSettings` | NOT present | WARN |
-
-These five shadow-specific settings fields are added by `ShadowBehaviour::accessField()` under the `settings_key_offset` domain. pydsvdcapi does not implement them. They are not a cause of errors during device announcement but will be missing when dSS reads back settings for grey devices.
+| `onThreshold` | Not in base outputbehaviour | Only for ON_OFF function | INFO — correct gating |
+| Shadow timing fields | In ShadowBehaviour | Present when set, gated on `primaryGroup == 2` | **FIXED** — now implemented |
 
 ---
 
@@ -131,7 +136,7 @@ From `channelDescProperties` in `channelbehaviour.cpp`:
 |---|---|---|
 | `name` | `string` | Channel name, e.g. `"brightness"`, `"shadePositionOutside"` |
 | `channelIndex` | `uint64` | **Deprecated in API v3+** — returns `mChannelIndex`; NOT returned for API version ≥ 3 |
-| `dsIndex` | `uint64` | Returns `mChannelIndex` (same value as channelIndex); always returned |
+| `dsIndex` | `uint64` | Returns `mChannelIndex`; always returned |
 | `channelType` | `uint64` | DsChannelType enum value |
 | `siunit` | `string` | SI unit name, e.g. `"percent"`, `"kelvin"`, `"degree"` |
 | `symbol` | `string` | Unit symbol string, e.g. `"%"`, `"K"`, `"°"` |
@@ -140,7 +145,33 @@ From `channelDescProperties` in `channelbehaviour.cpp`:
 | `resolution` | `double` | |
 | `values` | object/container | Enum values list — only present when `!REDUCED_FOOTPRINT` |
 
-**Key detail — element naming (keying)**: In p44vdc the channel description sub-tree is a container keyed by the **channel's `dsIndex` integer** (as string), not by channel name. Each child `PropertyElement` is named with the channel's numeric index (e.g. `"0"`, `"1"`), and within that element the `name` field carries the channel name string.
+**Key detail — element naming (keying)**: In p44vdc the channel container key is determined by `ChannelBehaviour::getApiId(aApiVersion)` (`channelbehaviour.cpp`), called from `Device::getDescriptorByIndex` for all three channel containers:
+
+```cpp
+string ChannelBehaviour::getApiId(int aApiVersion)
+{
+  if (aApiVersion>=3 && !mChannelId.empty()) {
+    return mChannelId;   // channel name string, e.g. "brightness", "shadePositionOutside"
+  }
+  else {
+    return string_format("%d", getChannelType());  // decimal channel TYPE (not dsIndex)
+  }
+}
+```
+
+- **API v3+** (current vdSM): key = channel **name string** (e.g. `"brightness"`, `"shadePositionOutside"`)
+- **API v2 and earlier**: key = decimal string of the **channel type enum** (e.g. `"1"` for `channeltype_brightness`) — **not** the dsIndex
+
+The `dsIndex` value (`mChannelIndex`) is **never** used as the container element key in any path. It appears only as a named field *inside* the channel's description object. This applies identically to `channelDescriptions`, `channelSettings`, and `channelStates`, for **all device classes** — verified:
+
+- `LightBehaviour`, `ShadowBehaviour`: no override
+- `ClimateControlBehaviour`: overrides only behaviour-level descriptors (`climatecontrol_key`), not channel container keys
+- `AudioBehaviour`/`AudioScene`: overrides only scene-level properties (`audioscene_key`), not channel keys
+- `CustomDevice`: no override of any channel key logic; inherits unchanged from `Device`
+
+**`VDC_SEND_ANNOUNCE_DEVICE`**: carries no property data at all — only `vdc_dSUID`. The vdSM then issues `getProperty` requests after acknowledgment, which go through the standard path above.
+
+**Incoming `setProperty`** (`Device::getDescriptorByName`): matches channel elements by the same `getApiId()` output — channel name string (API v3+), channel type decimal (API v2), or the literal `"0"` as a backward-compat alias for the first channel. `dsIndex` values are **not** a valid key for incoming property writes.
 
 **Shade channel specs (from `shadowbehaviour.hpp`)**:
 
@@ -153,48 +184,43 @@ From `channelDescProperties` in `channelbehaviour.cpp`:
 - Position channel: dsIndex = 0 (added first)
 - Angle channel: dsIndex = 1 (added second)
 
-### pydsvdcapi
+### pydsvdcapi (current)
 
-From `output_channel.py` `get_description_properties()` (line 622–636):
+From `output_channel.py` `get_description_properties()`:
 
 | Field name | Type | Notes |
 |---|---|---|
 | `name` | str | |
 | `channelType` | int | |
 | `dsIndex` | int | |
+| `siunit` | str | **FIXED** — now always present from `ChannelSpec` |
+| `symbol` | str | **FIXED** — now always present from `ChannelSpec` |
 | `min` | float | |
 | `max` | float | |
 | `resolution` | float | |
+| `values` | dict `{str: str}` | **NEW** — present for enum channels (e.g. FCU operation mode, power state) |
 
-**Key detail — element naming (keying)**: pydsvdcapi keys channel descriptions by **channel name** (e.g. `"shadePositionOutside"`), not by integer dsIndex. This is documented explicitly in `output_channel.py` docstring and `output.py` (lines 36–39).
+**Key detail — element naming (keying)**: pydsvdcapi keys channel containers by **channel name string** (e.g. `"shadePositionOutside"`), matching p44vdc's API v3+ behaviour. A backward-compat `_ChannelCompatDict` additionally resolves numeric keys (channel type decimal strings and `"0"` as default-channel alias) at `getProperty` time, covering the API v2 and legacy cases.
 
 **Shade channel specs** from `CHANNEL_SPECS` in `output_channel.py`:
 
-| Channel | `channelType` | name | min | max | resolution |
-|---|---|---|---|---|---|
-| SHADE_POSITION_OUTSIDE | enum value | `"shadePositionOutside"` | 0 | 100 | 100/255 ≈ 0.3922 |
-| SHADE_POSITION_INDOOR | enum value | `"shadePositionIndoor"` | 0 | 100 | 100/255 ≈ 0.3922 |
-| SHADE_OPENING_ANGLE_OUTSIDE | enum value | `"shadeOpeningAngleOutside"` | 0 | 100 | 100/255 ≈ 0.3922 |
-| SHADE_OPENING_ANGLE_INDOOR | enum value | `"shadeOpeningAngleIndoor"` | 0 | 100 | 100/255 ≈ 0.3922 |
+| Channel | `channelType` | name | min | max | resolution | siunit | symbol |
+|---|---|---|---|---|---|---|---|
+| SHADE_POSITION_OUTSIDE | enum value | `"shadePositionOutside"` | 0 | 100 | 100/65536 ≈ 0.001526 | `"percent"` | `"%"` |
+| SHADE_POSITION_INDOOR | enum value | `"shadePositionIndoor"` | 0 | 100 | 100/65536 ≈ 0.001526 | `"percent"` | `"%"` |
+| SHADE_OPENING_ANGLE_OUTSIDE | enum value | `"shadeOpeningAngleOutside"` | 0 | 100 | 100/65536 ≈ 0.001526 | `"percent"` | `"%"` |
+| SHADE_OPENING_ANGLE_INDOOR | enum value | `"shadeOpeningAngleIndoor"` | 0 | 100 | 100/65536 ≈ 0.001526 | `"percent"` | `"%"` |
 
 ### Differences
 
 | Field | p44vdc | pydsvdcapi | Severity |
 |---|---|---|---|
-| Element key (container child name) | **Integer dsIndex as string** (e.g. `"0"`, `"1"`) | **Channel name string** (e.g. `"shadePositionOutside"`) | **CRITICAL** — This is the most fundamental structural difference; see discussion below |
-| `siunit` | Present — e.g. `"percent"` for shade channels | **NOT present** | **CRITICAL** — dSS firmware may rely on `siunit` to render units correctly |
-| `symbol` | Present — e.g. `"%"` for shade channels | **NOT present** | WARN — unit symbol for display |
+| Element key (container child name) | **Channel name string** for API v3+ (e.g. `"shadePositionOutside"`); channel type decimal for API v2 | **Channel name string** always; numeric compat layer covers type-decimal and `"0"` alias | None — identical for API v3+; compat layer covers older paths |
+| `siunit` | Present | **FIXED** — now always present | ~~CRITICAL~~ → resolved |
+| `symbol` | Present | **FIXED** — now always present | ~~CRITICAL~~ → resolved |
+| `values` | Present (enum list, non-reduced builds) | Present for enum channels | INFO — now implemented for discrete-value channels |
 | `channelIndex` | Present (deprecated, API < 3) | NOT present | INFO — deprecated field |
-| `resolution` | 100/65536 ≈ 0.001526 for shade channels | 100/255 ≈ 0.392 for shade channels | **WARN** — p44vdc uses higher-resolution 16-bit scale; pydsvdcapi uses 8-bit scale |
-| `values` | Present (enum value list, non-reduced builds) | NOT present | INFO — rarely needed |
-
-**CRITICAL discussion on element key format**:
-
-The comment in `pydsvdcapi/output.py` lines 36–39 says that using channel name as key was intentional to fix a `deviceOutputIndex:255` error. However, p44vdc itself uses the integer dsIndex as the element key. The vdSM uses `getChannelById()` in p44vdc to resolve `channelId` strings — this works because the channel *name* field **inside** the element (not the element key) is used for lookup, while the **element key** is the numeric index.
-
-The vdSM therefore sees `channelDescriptions` keyed by integers (p44vdc) vs keyed by names (pydsvdcapi). This discrepancy likely does not cause a direct crash, but:
-- For grey/shade devices specifically, the dSS firmware does position/angle lookups by channel type or channel name from within the descriptor element — which pydsvdcapi correctly provides.
-- However, if dSS iterates the container expecting integer keys and tries to use them as indices, it would fail silently or produce wrong results with pydsvdcapi's name keys.
+| `resolution` (shade) | 100/65536 ≈ 0.001526 | **FIXED** — 100/65536 ≈ 0.001526 | ~~WARN~~ → resolved |
 
 ---
 
@@ -204,15 +230,13 @@ The vdSM therefore sees `channelDescriptions` keyed by integers (p44vdc) vs keye
 
 From `channelbehaviour.cpp`: Settings properties are **empty** (`numSettingsProperties = 0`). No fields defined.
 
-### pydsvdcapi
-
-From `output_channel.py` `get_settings_properties()` (line 638–645):
+### pydsvdcapi (current)
 
 Returns an **empty dict** `{}` for all channels.
 
 ### Differences
 
-None — both return empty settings. No difference.
+None — both return empty settings.
 
 ---
 
@@ -225,23 +249,21 @@ From `channelStateProperties` in `channelbehaviour.cpp`:
 | Field name | Type | Notes |
 |---|---|---|
 | `value` | `double` | Current channel value; `null` when unknown |
-| `age` | `double` | Seconds since last hardware sync as double; `null` when `mChannelLastSync==Never` or value is volatile |
+| `age` | `double` | Seconds since last hardware sync; `null` when `mChannelLastSync==Never` or volatile |
 | `x-p44-transitional` | `double` | Intermediate value during transition (p44 extension) |
 | `x-p44-transitiontimeleft` | `double` | Remaining transition time (p44 extension) |
 | `x-p44-progress` | `double` | Transition completion % (p44 extension) |
 
-**No `error` field** in channel states. Error lives in `outputState` at the output level, not per channel.
+**No `error` field** in channel states — error lives in `outputState` at the output level.
 
-**`age` semantics**: `age` is `null` (not `0`) when the value was never confirmed, or when `mChannelLastSync` is `Never`. When a value has been confirmed, `age` is `(MainLoop::now() - mChannelLastSync) / Second` as a double.
+### pydsvdcapi (current)
 
-### pydsvdcapi
-
-From `output_channel.py` `get_state_properties()` (line 647–657):
+From `output_channel.py` `get_state_properties()`:
 
 | Field name | Type | Notes |
 |---|---|---|
 | `value` | float or None | `None` when unknown → serialised as null |
-| `age` | float or None | `time.monotonic() - _last_update` when known; `None` when `_last_update is None` |
+| `age` | float or None | `time.monotonic() - _last_update` when known; `None` when never set |
 
 ### Differences
 
@@ -250,10 +272,7 @@ From `output_channel.py` `get_state_properties()` (line 647–657):
 | `x-p44-transitional` | Present (p44 extension) | NOT present | INFO — p44 extension only |
 | `x-p44-transitiontimeleft` | Present (p44 extension) | NOT present | INFO — p44 extension only |
 | `x-p44-progress` | Present (p44 extension) | NOT present | INFO — p44 extension only |
-| `age` null semantics | `null` when never confirmed | `None` (null) when `_last_update is None` | INFO — same semantics, consistent |
-| `error` | NOT in channelStates (only in outputState) | NOT in channelStates | None — both agree |
-
-**Assessment**: Channel states match well between p44vdc and pydsvdcapi. The only differences are p44-specific extension fields that pydsvdcapi does not include. This area is unlikely to cause errors.
+| `age` null semantics | `null` when never confirmed | `None` (null) when `_last_update is None` | INFO — same semantics |
 
 ---
 
@@ -261,21 +280,21 @@ From `output_channel.py` `get_state_properties()` (line 647–657):
 
 ### p44vdc
 
-p44vdc sends push notifications via `pushOutputState()` / `reportOutputState()`. The pushed property tree for a channel state update contains:
+p44vdc sends push notifications via `pushNotification` → `accessProperty` with the same API version as regular `getProperty` responses. The pushed property tree for a channel state update contains:
 
 ```
 changedproperties:
   PropertyElement(name="channelStates"):
-    PropertyElement(name="<dsIndex>"):   ← integer string, e.g. "0"
+    PropertyElement(name="<channelId>"):   ← channel name string for API v3+ (e.g. "shadePositionOutside")
       PropertyElement(name="value", value=<double>)
       PropertyElement(name="age", value=<double>)
 ```
 
-The element key within `channelStates` is the **integer dsIndex** (as string, e.g. `"0"` for the position channel), consistent with how `getProperty` responses are structured.
+The element key is produced by the same `Device::getDescriptorByIndex` → `getApiId(aApiVersion)` path as `getProperty`. For API v3+ this is the **channel name string**.
 
-### pydsvdcapi
+### pydsvdcapi (current)
 
-From `output.py` `_push_channel_state()` (line 1408–1453):
+From `output.py` `_push_channel_state()`:
 
 ```python
 push_tree = {
@@ -285,26 +304,16 @@ push_tree = {
 }
 ```
 
-The element key within `channelStates` is the **channel name string** (e.g. `"shadePositionOutside"`).
+The element key within `channelStates` is the **channel name string**.
 
 ### Differences
 
 | Aspect | p44vdc | pydsvdcapi | Severity |
 |---|---|---|---|
-| `channelStates` child element key in push | Integer dsIndex as string, e.g. `"0"` | Channel name string, e.g. `"shadePositionOutside"` | **CRITICAL** for grey devices — see discussion |
+| `channelStates` child element key in push | Channel name string for API v3+ (e.g. `"shadePositionOutside"`) | Channel name string (e.g. `"shadePositionOutside"`) | None — identical for API v3+ |
 | Properties pushed | `value`, `age` | `value`, `age` | None |
 
-**CRITICAL discussion on push notification key format for grey devices**:
-
-This is the most likely root cause of errors on grey (shade) devices:
-
-- The vdSM (dSS firmware) receives a `VDC_SEND_PUSH_NOTIFICATION` for `channelStates`.
-- It tries to match the child element name against its registered channel lookup table.
-- For yellow (dimmer/CT/RGB) devices: p44vdc uses `"0"` for brightness. dSS may look up channel index 0 and find the brightness channel. When pydsvdcapi sends `"brightness"`, dSS may also accept this because it falls back to name lookup — explaining why yellow devices work.
-- For grey (shade) devices: p44vdc uses `"0"` for position, `"1"` for angle. If dSS does integer-index matching, pydsvdcapi's `"shadePositionOutside"` key will not match index `"0"`, causing the push to be silently ignored or logged as `deviceOutputIndex:255`.
-- However, the pydsvdcapi comment in `output.py` line 39 states that switching *to* name-keying fixed the `deviceOutputIndex:255` errors. This suggests dSS for API v3+ does support name-keyed lookup. The discrepancy vs p44vdc may be in which API version the push notification uses.
-
-**Conclusion**: The key format difference exists but may be intentional in pydsvdcapi. The `deviceOutputIndex:255` errors users see are more likely caused by item 3 (missing `siunit` in channelDescriptions) or item 7 (channelId matching in setOutputChannelValue) than by the push key format.
+**Note**: Earlier analysis incorrectly stated p44vdc uses `dsIndex` as the push key. The actual p44vdc source (`pushNotification` → `accessProperty` → `Device::getDescriptorByIndex` → `getApiId()`) returns the channel name string for API v3+, identical to pydsvdcapi.
 
 ---
 
@@ -320,13 +329,9 @@ In `customdevice.cpp`, channel resolution for `setOutputChannelValue` uses three
 
 `getChannelById()` matches on the channel's **name string** (the `channelId` in the notification).
 
-In `outputbehaviour.cpp`, the `getChannelById()` implementation iterates all channels and returns the first one where `cb->getChannelId() == aId`. The `getChannelId()` of a channel returns its **name string** (e.g. `"shadePositionOutside"`).
+### pydsvdcapi (current)
 
-The `VDSM_NOTIFICATION_SET_OUTPUT_CHANNEL_VALUE` protobuf message has a `channelId` field that carries the channel name string (API v3+) and a `channel` field that carries the integer type (API v1/v2).
-
-### pydsvdcapi
-
-From `vdc_host.py` `_handle_set_output_channel_value()` (line 1868–1938):
+From `vdc_host.py` `_handle_set_output_channel_value()`:
 
 ```python
 # Priority 1: channelId (name string)
@@ -346,15 +351,13 @@ if channel_obj is None and notif.HasField("channel"):
 
 | Aspect | p44vdc | pydsvdcapi | Severity |
 |---|---|---|---|
-| channelId lookup priority | index → type → id (name) | name (channelId) → type | INFO — functionally equivalent for API v3+; index-based is not supported in pydsvdcapi |
-| Index-based fallback | Supported (`"index"` field) | NOT supported | INFO — deprecated path; not used by modern vdSM |
-| Name matching | `getChannelId()` = channel name string | `ch.name == notif.channelId` | None — same result |
-
-**Assessment**: Channel lookup for `setOutputChannelValue` is functionally equivalent for API v3+ (which uses `channelId` = name string). The missing index-based lookup is a deprecated fallback and not the cause of grey device errors.
+| channelId lookup priority | index → type → id (name) | name (channelId) → type | INFO — functionally equivalent for API v3+; integer-index path is deprecated |
+| Index-based fallback | Supported | NOT supported | INFO — deprecated path; not used by modern vdSM |
+| Name matching | `getChannelId()` = channel name | `ch.name == notif.channelId` | None — same result |
 
 ---
 
-## 8. `outputState` (formerly `outputState` vs `outputState`)
+## 8. `outputState`
 
 ### p44vdc
 
@@ -367,21 +370,25 @@ From `outputStateProperties` in `outputbehaviour.cpp`:
 
 **No `error` field in outputState in base OutputBehaviour.**
 
-### pydsvdcapi
+### pydsvdcapi (current)
 
-From `output.py` `get_state_properties()` (line 1550–1558):
+From `output.py` `get_state_properties()`:
 
 | Field | Type | Notes |
 |---|---|---|
 | `localPriority` | bool | |
-| `error` | int | OutputError enum value |
+| `transitionTime` | double | **FIXED** — now present |
+| `error` | int | OutputError enum value; extra field not in p44vdc base |
+
+**Note**: `movingState` was present in earlier pydsvdcapi versions but has been **removed** — it was never part of the VDC API spec and not emitted by p44vdc.
 
 ### Differences
 
 | Field | p44vdc | pydsvdcapi | Severity |
 |---|---|---|---|
-| `transitionTime` | Present (double, seconds) | NOT present | WARN — dSS may read this to track active transitions |
-| `error` | NOT in base outputState | Always present (int) | **WARN** — pydsvdcapi sends an extra `error` field; not expected by dSS; likely harmless but non-standard |
+| `transitionTime` | Present | **FIXED** — now present | ~~WARN~~ → resolved |
+| `error` | NOT in base outputState | Always present | INFO — extra field; likely harmless |
+| `movingState` | NOT in VDC API | **REMOVED** | resolved — no longer emitted |
 
 ---
 
@@ -389,32 +396,40 @@ From `output.py` `get_state_properties()` (line 1550–1558):
 
 ### p44vdc
 
-`modelFeatures` is encoded in the property tree as a **boolean container array** (`apivalue_object + propflag_container`). Each enabled feature is a child element named by the feature name string with a boolean `true` value. p44vdc iterates over `numModelFeatures` known features in order.
+`modelFeatures` is encoded as a **boolean container array** (`apivalue_object + propflag_container`). Each enabled feature is a child element named by the feature name string with a boolean `true` value. p44vdc iterates features in canonical `ModelFeatureId` enum order (from `modelconst.h`).
 
-### pydsvdcapi
+### pydsvdcapi (current)
 
-From `vdsd.py` `get_properties()` (line 1556–1560):
+From `vdsd.py` `get_properties()`:
 
 ```python
-props["modelFeatures"] = {f: True for f in sorted(self._model_features)}
+_MODEL_FEATURE_ORDER = {
+    "dontcare": 0, "blink": 1, "transt": 4, "outmode": 5, ...
+}
+props["modelFeatures"] = {
+    f: True
+    for f in sorted(self._model_features, key=lambda x: _MODEL_FEATURE_ORDER.get(x, 999))
+}
 ```
 
-An object (dict) where each key is the feature name string and each value is `True`. Absent features are simply not included.
+An object (dict) where each key is the feature name string and each value is `True`. Absent features are not emitted. Order follows the canonical `ModelFeatureId` enum index from `modelconst.h`.
 
 ### Differences
 
 | Aspect | p44vdc | pydsvdcapi | Severity |
 |---|---|---|---|
-| Absent features | Explicitly emitted as `false` values (full container) | Not emitted at all | WARN — Functionally equivalent since absent = false, but dSS may iterate a fixed set |
-| Feature ordering | Fixed canonical order by enum index | Alphabetical sort | INFO — irrelevant to semantics |
+| Absent features | Explicitly emitted as `false` (full container) | Not emitted | INFO — absent = false; functionally equivalent |
+| Feature ordering | Canonical enum index order | **FIXED** — now canonical enum index order | ~~INFO~~ → resolved |
 
 ---
 
 ## 10. `groups` in `outputSettings` — encoding detail
 
-This is a known subtlety. p44vdc emits `groups` as a container of 64 boolean values (indices 0–63), with `true` for member groups and `false` for non-member groups. pydsvdcapi emits only the `true` entries as a dict.
+p44vdc emits `groups` as a container of 64 boolean values (indices 0–63), with `true` for member groups and `false` for non-member groups. pydsvdcapi emits only the `true` entries.
 
-For **write-back** via `setProperty`, the vdSM sends group membership changes as individual `{index: bool}` entries. pydsvdcapi handles this correctly in `apply_settings()`. For **read** via `getProperty`, pydsvdcapi sends only true entries; this should be fine as the vdSM initialises group membership from the true entries.
+For **write-back** via `setProperty`, the vdSM sends group membership changes as individual `{index: bool}` entries — pydsvdcapi handles this correctly in `apply_settings()`. For **read** via `getProperty`, pydsvdcapi sends only true entries; the vdSM correctly infers non-listed groups as non-members.
+
+Emitting all 64 entries was tested and found to cause excessive individual `groupMembership` queries from the vdSM (64 per device), significantly slowing announcement. The true-only format was deliberately retained.
 
 ---
 
@@ -433,64 +448,50 @@ Key fields sent in `VDC_SEND_ANNOUNCE_DEVICE` / `getProperty` response for a dev
 | `model` | |
 | `hardwareGuid` | |
 | `vendorName` | |
-| `modelFeatures` | bool container, see section 9 |
+| `modelFeatures` | bool container — canonical order |
 | `outputDescription` | single object |
 | `outputSettings` | single object |
 | `outputState` | single object |
-| `channelDescriptions` | container keyed by integer dsIndex |
-| `channelSettings` | container keyed by integer dsIndex |
-| `channelStates` | container keyed by integer dsIndex |
+| `channelDescriptions` | container keyed by channel name string (API v3+) or channel type decimal (API v2) |
+| `channelSettings` | container keyed by channel name string (API v3+) or channel type decimal (API v2) |
+| `channelStates` | container keyed by channel name string (API v3+) or channel type decimal (API v2) |
 
-### pydsvdcapi
+### pydsvdcapi (current)
 
-Same top-level fields, with differences noted above. Channel containers are keyed by channel name instead of integer dsIndex.
-
----
-
-## Summary: Most Critical Differences
-
-### CRITICAL
-
-1. **`siunit` and `symbol` missing from `channelDescriptions`** (section 3):
-   p44vdc sends `siunit` (e.g. `"percent"`) and `symbol` (e.g. `"%"`) for every channel. pydsvdcapi omits these entirely. The dSS firmware uses `siunit` to validate channel value ranges and to display units in the UI. For grey devices, missing `siunit` on shade channels may cause the dSS to reject or misinterpret the channel descriptors.
-
-2. **`resolution` value differs significantly for shade channels** (section 3):
-   p44vdc uses `100/65536 ≈ 0.001526` (16-bit precision) for shade position and angle channels. pydsvdcapi uses `100/255 ≈ 0.392` (8-bit precision). A higher-resolution value from p44vdc allows finer positioning. If dSS firmware validates that transmitted values are multiples of resolution, pydsvdcapi's coarser resolution could trigger rounding errors.
-
-3. **Push notification key format discrepancy** (section 6):
-   p44vdc keys `channelStates` children by integer dsIndex; pydsvdcapi keys by channel name. While pydsvdcapi's approach appears to work for yellow devices (confirmed by users), the root of the `deviceOutputIndex:255` errors on grey devices may lie in this area if the dSS firmware uses different code paths for grey (shade) vs yellow (light) channel state updates.
-
-### WARN
-
-4. **`openTime`, `closeTime`, `angleOpenTime`, `angleCloseTime`, `stopDelayTime` missing** (section 2):
-   These shadow-specific settings fields are present in p44vdc's `ShadowBehaviour` and are part of `outputSettings` for grey devices. pydsvdcapi does not include them. If dSS firmware tries to read motor timing from these fields and they are absent, it falls back to defaults, which should be non-fatal. If dSS writes these fields, pydsvdcapi's `apply_settings()` silently ignores them.
-
-5. **`transitionTime` missing from `outputState`** (section 8):
-   pydsvdcapi does not include `transitionTime` in `outputState`. The dSS may read this to track whether a transition is in progress (especially relevant for position-based shade movements). This could cause the dSS shade control logic to mis-time movements.
-
-6. **`error` extra field in `outputState`** (section 8):
-   pydsvdcapi always sends `error: 0` in outputState. p44vdc base does not include this field. Likely harmless but non-standard.
-
-7. **`groups` encoding in `outputSettings`** (section 10):
-   p44vdc sends all 64 group indices (true/false). pydsvdcapi sends only true entries. Functionally equivalent for reading but different in wire format.
-
-### INFO
-
-8. Extra fields in `outputDescription` (`name`, `defaultGroup`) — harmless.
-9. Missing p44-specific extension fields (`x-p44-recommendedTransitionTime`, `x-p44-bridgePushInterval`, `x-p44-transitional`, `x-p44-transitiontimeleft`, `x-p44-progress`) — not required.
-10. `channelIndex` (deprecated) missing — correct for API v3+.
-11. `values` (enum value list) missing from channelDescriptions — rarely used.
+Same top-level fields. Channel containers are keyed by channel name (with numeric-key backward-compat resolution via `_ChannelCompatDict`).
 
 ---
 
-## Recommended Fixes (Priority Order)
+## Summary: Current Status
 
-1. **Add `siunit` and `symbol` to `channelDescriptions`** in `OutputChannel.get_description_properties()`. Shade channels should report `siunit="percent"`, `symbol="%"`. Light channels: `brightness` → `siunit="percent"`, `symbol="%"`; `colortemp` → `siunit="reciprocal megakelvin"`, `symbol="mired"`; `hue` → `siunit="degree"`, `symbol="°"`.
+### Resolved (previously CRITICAL/WARN)
 
-2. **Review `resolution` for shade channels**: Consider whether the p44vdc value of `100/65536` is more appropriate than `100/255`. The spec likely expects this to match the hardware's actual positioning granularity.
+1. ~~**`siunit` and `symbol` missing from `channelDescriptions`**~~ — **FIXED**: now always present from `ChannelSpec`.
 
-3. **Add `transitionTime` to `outputState`**: Add a `transitionTime` field (float, seconds, current active transition duration) to `Output.get_state_properties()`.
+2. ~~**`transitionTime` missing from `outputState`**~~ — **FIXED**: now present.
 
-4. **Investigate push notification key format**: Verify experimentally whether grey-device push failures are due to the name vs integer key in `channelStates` push notifications.
+3. ~~**Shadow timing fields missing from `outputSettings`**~~ — **FIXED**: `openTime`, `closeTime`, `angleOpenTime`, `angleCloseTime`, `stopDelayTime` now implemented, gated on `primaryGroup == 2`.
 
-5. **Add shadow-specific outputSettings fields**: Add `openTime`, `closeTime`, `angleOpenTime`, `angleCloseTime`, `stopDelayTime` as optional float fields to `Output` (and handle them in `apply_settings()`), to match what p44vdc's ShadowBehaviour exposes.
+4. ~~**`name` and `defaultGroup` always in `outputDescription`**~~ — **FIXED**: now optional, only when explicitly set.
+
+5. ~~**`activeGroup` always in `outputSettings`**~~ — **FIXED**: now optional, only when explicitly set.
+
+6. ~~**`modelFeatures` order was alphabetical**~~ — **FIXED**: now sorted by canonical `ModelFeatureId` enum index.
+
+7. ~~**`movingState` in `outputState`**~~ — **REMOVED**: was non-standard, never in VDC API spec.
+
+### Remaining Differences
+
+| # | Area | p44vdc | pydsvdcapi | Severity |
+|---|---|---|---|---|
+| A | `groups` encoding | All 64 entries (true/false) | True entries only | INFO — functionally equivalent; full-64 deliberately avoided (performance) |
+| B | `resolution` for shade channels | 100/65536 ≈ 0.001526 | 100/65536 ≈ 0.001526 | ~~WARN~~ → resolved |
+| C | Channel container key | Channel name string (API v3+); channel type decimal (API v2) | Channel name string; compat layer handles type-decimal and `"0"` alias | None — identical for API v3+ |
+| D | `values` in channelDescriptions | All channels | Enum channels only | INFO — correctly scoped |
+| E | `error` in `outputState` | NOT present | Always present | INFO — extra field, harmless |
+| F | p44-specific extension fields | Present | NOT present | INFO — not required |
+| G | `channelIndex` (deprecated) | Present (API < 3) | NOT present | INFO — correct for API v3+ |
+
+### No open items
+
+All previously identified CRITICAL and WARN differences have been resolved. The remaining differences (A, C–G) are all INFO-level and either deliberate design choices or non-standard extras that are harmless in practice.

--- a/docs/superpowers/plans/2026-06-23-settings-callbacks.md
+++ b/docs/superpowers/plans/2026-06-23-settings-callbacks.md
@@ -1,0 +1,1019 @@
+# Settings Callbacks and Push Notifications Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add (a) optional `on_settings_changed` callbacks that fire when the vdSM writes settings to any component, and (b) `push_settings()` methods on each component so device code can push settings changes to the vdSM via `VDC_SEND_PUSH_NOTIFICATION`.
+
+**Architecture:** Each of the four settable component types (`Output`, `BinaryInput`, `ButtonInput`, `SensorInput`) gains a callback property and a push method, following the exact same pattern already used by channel-state pushes (`Output._push_channel_state`) and state pushes (`BinaryInput._push_state`). The `vdc_host.py` call sites for `apply_settings()` are extended to `await` an optional async callback after the apply. New callback type aliases are exported from `__init__.py`.
+
+**Tech Stack:** Python 3.10+, asyncio, protobuf (`vdc_messages_pb2`), pytest-asyncio, existing `dict_to_elements()` helper.
+
+---
+
+## File Map
+
+| File | Change |
+|------|--------|
+| `src/pydsvdcapi/output.py` | Add `OutputSettingsChangedCallback` type alias, `on_settings_changed` property, call in `apply_settings()`, add `push_settings()` method |
+| `src/pydsvdcapi/binary_input.py` | Add `BinaryInputSettingsChangedCallback` type alias, `on_settings_changed` property, call in `apply_settings()`, add `push_settings()` method |
+| `src/pydsvdcapi/button_input.py` | Add `ButtonInputSettingsChangedCallback` type alias, `on_settings_changed` property, call in `apply_settings()`, add `push_settings()` method |
+| `src/pydsvdcapi/sensor_input.py` | Add `SensorInputSettingsChangedCallback` type alias, `on_settings_changed` property, call in `apply_settings()`, add `push_settings()` method |
+| `src/pydsvdcapi/vdc_host.py` | Make `_apply_vdsd_set_property` async; `await` callbacks after each `apply_settings()` call |
+| `src/pydsvdcapi/__init__.py` | Export the four new callback type aliases |
+| `tests/test_settings_callbacks.py` | New test file: callback firing, push notification content, no-session guard |
+
+---
+
+## Invariants to preserve throughout
+
+- The callback receives only the dict of settings that **arrived in the setProperty request** (the `incoming` / `settings` argument to `apply_settings()`), not the full settings object. This lets the application know exactly what changed.
+- Callbacks are async. If they raise, the exception is logged and swallowed (same pattern as `on_channel_applied` in `output.py`).
+- `push_settings()` is a no-op when no session is active or the vdSD is not yet announced (same guard as `_push_state()`).
+- `apply_settings()` remains synchronous. The callback is invoked via `asyncio.ensure_future` / scheduled via `create_task` from `vdc_host.py` after the synchronous apply completes. Alternatively, `_apply_vdsd_set_property` is made `async` so it can `await` the callback directly — this is the cleaner approach (see Task 5).
+
+---
+
+## Task 1 — `OutputSettingsChangedCallback` + `Output.on_settings_changed` property
+
+**Files:**
+- Modify: `src/pydsvdcapi/output.py` (around line 104–120 for type alias; around line 660–670 for `__init__`; around line 998–1013 for property pattern)
+
+- [ ] **Step 1: Add type alias after `DimChannelCallback` (line ~120)**
+
+```python
+#: Type alias for the output-settings-changed callback.
+#: ``async def callback(output: Output, changed: dict[str, Any]) -> None``
+#: *changed* is the dict of keys that arrived in the ``setProperty`` request.
+OutputSettingsChangedCallback = Callable[
+    ["Output", dict[str, Any]],
+    Coroutine[Any, Any, None],
+]
+```
+
+- [ ] **Step 2: Add instance attribute in `Output.__init__`** (after the `_on_dim_channel` line, ~line 666)
+
+```python
+#: Callback invoked when vdSM writes outputSettings.
+self._on_settings_changed: OutputSettingsChangedCallback | None = None
+```
+
+- [ ] **Step 3: Add `on_settings_changed` property** (after the `on_dim_channel` setter, ~line 1013)
+
+```python
+@property
+def on_settings_changed(self) -> OutputSettingsChangedCallback | None:
+    """Callback invoked when the vdSM writes ``outputSettings``."""
+    return self._on_settings_changed
+
+@on_settings_changed.setter
+def on_settings_changed(self, callback: OutputSettingsChangedCallback | None) -> None:
+    self._on_settings_changed = callback
+```
+
+- [ ] **Step 4: Verify the file still passes ruff + mypy**
+
+```bash
+cd /home/arne/Development/pyDSvDCAPI/pyDSvDCAPI
+ruff check src/pydsvdcapi/output.py
+mypy src/pydsvdcapi/output.py
+```
+
+Expected: no errors.
+
+- [ ] **Step 5: Commit (no tests yet — tests come in Task 7)**
+
+```bash
+git add src/pydsvdcapi/output.py
+git commit -m "feat(output): add OutputSettingsChangedCallback type and on_settings_changed property"
+```
+
+---
+
+## Task 2 — `BinaryInputSettingsChangedCallback` + `BinaryInput.on_settings_changed`
+
+**Files:**
+- Modify: `src/pydsvdcapi/binary_input.py` (imports area for type alias; `__init__` for attribute; new property after `apply_settings`)
+
+- [ ] **Step 1: Add type alias near the top of `binary_input.py`** (after existing `Callable` / type alias imports)
+
+Look for where `Callable` and `Coroutine` are imported from `collections.abc` / `typing`. Add:
+
+```python
+#: Type alias for the binary-input-settings-changed callback.
+#: ``async def callback(binary_input: BinaryInput, changed: dict[str, Any]) -> None``
+BinaryInputSettingsChangedCallback = Callable[
+    ["BinaryInput", dict[str, Any]],
+    Coroutine[Any, Any, None],
+]
+```
+
+- [ ] **Step 2: Add instance attribute in `BinaryInput.__init__`**
+
+Grep for `self._session` init line in `__init__` (~line 151). Add directly after it:
+
+```python
+self._on_settings_changed: BinaryInputSettingsChangedCallback | None = None
+```
+
+- [ ] **Step 3: Add property after `apply_settings` method (after ~line 460)**
+
+```python
+@property
+def on_settings_changed(self) -> BinaryInputSettingsChangedCallback | None:
+    """Callback invoked when the vdSM writes ``binaryInputSettings``."""
+    return self._on_settings_changed
+
+@on_settings_changed.setter
+def on_settings_changed(self, callback: BinaryInputSettingsChangedCallback | None) -> None:
+    self._on_settings_changed = callback
+```
+
+- [ ] **Step 4: Verify ruff + mypy**
+
+```bash
+ruff check src/pydsvdcapi/binary_input.py
+mypy src/pydsvdcapi/binary_input.py
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pydsvdcapi/binary_input.py
+git commit -m "feat(binary_input): add BinaryInputSettingsChangedCallback type and on_settings_changed property"
+```
+
+---
+
+## Task 3 — `ButtonInputSettingsChangedCallback` + `ButtonInput.on_settings_changed`
+
+**Files:**
+- Modify: `src/pydsvdcapi/button_input.py`
+
+- [ ] **Step 1: Add type alias near the top of `button_input.py`**
+
+```python
+#: Type alias for the button-input-settings-changed callback.
+#: ``async def callback(button_input: ButtonInput, changed: dict[str, Any]) -> None``
+ButtonInputSettingsChangedCallback = Callable[
+    ["ButtonInput", dict[str, Any]],
+    Coroutine[Any, Any, None],
+]
+```
+
+- [ ] **Step 2: Add instance attribute in `ButtonInput.__init__`**
+
+```python
+self._on_settings_changed: ButtonInputSettingsChangedCallback | None = None
+```
+
+- [ ] **Step 3: Add property after `apply_settings` method (~line 1050)**
+
+```python
+@property
+def on_settings_changed(self) -> ButtonInputSettingsChangedCallback | None:
+    """Callback invoked when the vdSM writes ``buttonInputSettings``."""
+    return self._on_settings_changed
+
+@on_settings_changed.setter
+def on_settings_changed(self, callback: ButtonInputSettingsChangedCallback | None) -> None:
+    self._on_settings_changed = callback
+```
+
+- [ ] **Step 4: Verify ruff + mypy**
+
+```bash
+ruff check src/pydsvdcapi/button_input.py
+mypy src/pydsvdcapi/button_input.py
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pydsvdcapi/button_input.py
+git commit -m "feat(button_input): add ButtonInputSettingsChangedCallback type and on_settings_changed property"
+```
+
+---
+
+## Task 4 — `SensorInputSettingsChangedCallback` + `SensorInput.on_settings_changed`
+
+**Files:**
+- Modify: `src/pydsvdcapi/sensor_input.py`
+
+- [ ] **Step 1: Add type alias near the top of `sensor_input.py`**
+
+```python
+#: Type alias for the sensor-input-settings-changed callback.
+#: ``async def callback(sensor_input: SensorInput, changed: dict[str, Any]) -> None``
+SensorInputSettingsChangedCallback = Callable[
+    ["SensorInput", dict[str, Any]],
+    Coroutine[Any, Any, None],
+]
+```
+
+- [ ] **Step 2: Add instance attribute in `SensorInput.__init__`**
+
+```python
+self._on_settings_changed: SensorInputSettingsChangedCallback | None = None
+```
+
+- [ ] **Step 3: Add property after `apply_settings` method (~line 602)**
+
+```python
+@property
+def on_settings_changed(self) -> SensorInputSettingsChangedCallback | None:
+    """Callback invoked when the vdSM writes ``sensorSettings``."""
+    return self._on_settings_changed
+
+@on_settings_changed.setter
+def on_settings_changed(self, callback: SensorInputSettingsChangedCallback | None) -> None:
+    self._on_settings_changed = callback
+```
+
+- [ ] **Step 4: Verify ruff + mypy**
+
+```bash
+ruff check src/pydsvdcapi/sensor_input.py
+mypy src/pydsvdcapi/sensor_input.py
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/pydsvdcapi/sensor_input.py
+git commit -m "feat(sensor_input): add SensorInputSettingsChangedCallback type and on_settings_changed property"
+```
+
+---
+
+## Task 5 — Wire callbacks in `vdc_host.py`
+
+`_apply_vdsd_set_property` is currently synchronous. We make it `async` so it can `await` the optional callbacks after each `apply_settings()` call. The callers in `vdc_host.py` already run inside an async context and just need an `await` added.
+
+**Files:**
+- Modify: `src/pydsvdcapi/vdc_host.py` (line 1396 area and each `apply_settings()` call site)
+
+- [ ] **Step 1: Make `_apply_vdsd_set_property` async**
+
+Change line 1396:
+```python
+def _apply_vdsd_set_property(self, vdsd: Any, incoming: dict[str, Any]) -> None:
+```
+to:
+```python
+async def _apply_vdsd_set_property(self, vdsd: Any, incoming: dict[str, Any]) -> None:
+```
+
+- [ ] **Step 2: `await` the caller at line ~1373**
+
+Find where `_apply_vdsd_set_property` is called. It looks like:
+```python
+self._apply_vdsd_set_property(vdsd, incoming)
+```
+Change to:
+```python
+await self._apply_vdsd_set_property(vdsd, incoming)
+```
+
+The enclosing method is already `async` (it's inside the message-handling coroutine), so this is safe.
+
+- [ ] **Step 3: After `btn.apply_settings(settings)` (~line 1427), add callback invocation**
+
+```python
+btn.apply_settings(settings)
+logger.info(
+    "vdSD '%s' buttonInputSettings[%d] updated",
+    vdsd.dsuid,
+    idx,
+)
+if btn.on_settings_changed is not None:
+    try:
+        await btn.on_settings_changed(btn, settings)
+    except Exception:
+        logger.exception(
+            "on_settings_changed callback raised for buttonInput[%d] on vdSD '%s'",
+            idx,
+            vdsd.dsuid,
+        )
+```
+
+- [ ] **Step 4: After `bi.apply_settings(settings)` (~line 1446), add callback invocation**
+
+```python
+bi.apply_settings(settings)
+logger.info(
+    "vdSD '%s' binaryInputSettings[%d] updated",
+    vdsd.dsuid,
+    idx,
+)
+if bi.on_settings_changed is not None:
+    try:
+        await bi.on_settings_changed(bi, settings)
+    except Exception:
+        logger.exception(
+            "on_settings_changed callback raised for binaryInput[%d] on vdSD '%s'",
+            idx,
+            vdsd.dsuid,
+        )
+```
+
+- [ ] **Step 5: After `si.apply_settings(settings)` (~line 1465), add callback invocation**
+
+```python
+si.apply_settings(settings)
+logger.info(
+    "vdSD '%s' sensorSettings[%d] updated",
+    vdsd.dsuid,
+    idx,
+)
+if si.on_settings_changed is not None:
+    try:
+        await si.on_settings_changed(si, settings)
+    except Exception:
+        logger.exception(
+            "on_settings_changed callback raised for sensorInput[%d] on vdSD '%s'",
+            idx,
+            vdsd.dsuid,
+        )
+```
+
+- [ ] **Step 6: After `output.apply_settings(out_settings)` (~line 1477), add callback invocation**
+
+```python
+output.apply_settings(out_settings)
+logger.info(
+    "vdSD '%s' outputSettings updated",
+    vdsd.dsuid,
+)
+if output.on_settings_changed is not None:
+    try:
+        await output.on_settings_changed(output, out_settings)
+    except Exception:
+        logger.exception(
+            "on_settings_changed callback raised for output on vdSD '%s'",
+            vdsd.dsuid,
+        )
+```
+
+- [ ] **Step 7: Verify ruff + mypy on vdc_host**
+
+```bash
+ruff check src/pydsvdcapi/vdc_host.py
+mypy src/pydsvdcapi/vdc_host.py
+```
+
+- [ ] **Step 8: Run existing test suite to confirm nothing broke**
+
+```bash
+pytest tests/ -x -q
+```
+
+Expected: all existing tests pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/pydsvdcapi/vdc_host.py
+git commit -m "feat(vdc_host): invoke on_settings_changed callbacks after apply_settings"
+```
+
+---
+
+## Task 6 — `push_settings()` on all four component types
+
+Each component gets an async `push_settings()` method that sends `VDC_SEND_PUSH_NOTIFICATION` with the component's full settings subtree. The property-tree key matches what `vdsd.py` uses for `getProperty` responses:
+
+| Component | Property key | Index key |
+|-----------|-------------|-----------|
+| `Output` | `outputSettings` | (no index, singleton) |
+| `BinaryInput` | `binaryInputSettings` | `str(ds_index)` |
+| `ButtonInput` | `buttonInputSettings` | `str(ds_index)` |
+| `SensorInput` | `sensorSettings` | `str(ds_index)` |
+
+### 6a — `Output.push_settings()`
+
+**File:** `src/pydsvdcapi/output.py`
+
+Add after `_push_channel_state()` (~line 1654):
+
+```python
+async def push_settings(self) -> None:
+    """Push the current ``outputSettings`` to the vdSM.
+
+    Sends a ``VDC_SEND_PUSH_NOTIFICATION`` with the full
+    ``outputSettings`` property subtree.  A no-op if the session is
+    not active or the vdSD has not been announced.
+    """
+    session = self._session
+    if session is None:
+        logger.debug(
+            "No active session — skipping push_settings for output '%s'",
+            self._name,
+        )
+        return
+    if not self._vdsd.is_announced:
+        logger.debug(
+            "vdSD not announced — skipping push_settings for output '%s'",
+            self._name,
+        )
+        return
+
+    settings_dict = self.get_settings_properties()
+    push_tree: dict[str, Any] = {"outputSettings": settings_dict}
+
+    msg = pb.Message()
+    msg.type = pb.VDC_SEND_PUSH_NOTIFICATION
+    msg.vdc_send_push_notification.dSUID = str(self._vdsd.dsuid)
+    for elem in dict_to_elements(push_tree):
+        msg.vdc_send_push_notification.changedproperties.append(elem)
+
+    try:
+        await session.send_notification(msg)
+        logger.debug(
+            "Pushed outputSettings for vdSD %s: %s",
+            self._vdsd.dsuid,
+            settings_dict,
+        )
+    except (ConnectionError, OSError) as exc:
+        logger.warning(
+            "Failed to push outputSettings for vdSD %s: %s",
+            self._vdsd.dsuid,
+            exc,
+        )
+```
+
+### 6b — `BinaryInput.push_settings()`
+
+**File:** `src/pydsvdcapi/binary_input.py`
+
+Add after `_push_state()` (~line 571):
+
+```python
+async def push_settings(self, session: VdcSession | None = None) -> None:
+    """Push the current ``binaryInputSettings`` to the vdSM.
+
+    Sends a ``VDC_SEND_PUSH_NOTIFICATION`` carrying the full
+    ``binaryInputSettings`` subtree for this input.  A no-op if no
+    session is active or the vdSD is not announced.
+    """
+    session = session or self._session
+    if session is None:
+        logger.debug(
+            "BinaryInput[%d]: no active session — skipping push_settings",
+            self._ds_index,
+        )
+        return
+    if not self._vdsd.is_announced:
+        logger.debug(
+            "BinaryInput[%d]: vdSD not announced — skipping push_settings",
+            self._ds_index,
+        )
+        return
+
+    settings_dict = self.get_settings_properties()
+    push_tree: dict[str, Any] = {
+        "binaryInputSettings": {str(self._ds_index): settings_dict}
+    }
+
+    msg = pb.Message()
+    msg.type = pb.VDC_SEND_PUSH_NOTIFICATION
+    msg.vdc_send_push_notification.dSUID = str(self._vdsd.dsuid)
+    for elem in dict_to_elements(push_tree):
+        msg.vdc_send_push_notification.changedproperties.append(elem)
+
+    try:
+        await session.send_notification(msg)
+        logger.debug(
+            "BinaryInput[%d] '%s': pushed settings for vdSD %s",
+            self._ds_index,
+            self._name,
+            self._vdsd.dsuid,
+        )
+    except (ConnectionError, OSError) as exc:
+        logger.warning(
+            "BinaryInput[%d] '%s': failed to push settings: %s",
+            self._ds_index,
+            self._name,
+            exc,
+        )
+```
+
+### 6c — `ButtonInput.push_settings()`
+
+**File:** `src/pydsvdcapi/button_input.py`
+
+Add after the `apply_settings` method and `on_settings_changed` property (~line 1055). Follow the exact same pattern as 6b, substituting:
+- `BinaryInput` → `ButtonInput`
+- `"binaryInputSettings"` → `"buttonInputSettings"`
+- `self._ds_index` → `self._ds_index`
+- log prefix `"ButtonInput"`.
+
+Full method:
+
+```python
+async def push_settings(self, session: VdcSession | None = None) -> None:
+    """Push the current ``buttonInputSettings`` to the vdSM.
+
+    Sends a ``VDC_SEND_PUSH_NOTIFICATION`` carrying the full
+    ``buttonInputSettings`` subtree for this input.  A no-op if no
+    session is active or the vdSD is not announced.
+    """
+    session = session or self._session
+    if session is None:
+        logger.debug(
+            "ButtonInput[%d]: no active session — skipping push_settings",
+            self._ds_index,
+        )
+        return
+    if not self._vdsd.is_announced:
+        logger.debug(
+            "ButtonInput[%d]: vdSD not announced — skipping push_settings",
+            self._ds_index,
+        )
+        return
+
+    settings_dict = self.get_settings_properties()
+    push_tree: dict[str, Any] = {
+        "buttonInputSettings": {str(self._ds_index): settings_dict}
+    }
+
+    msg = pb.Message()
+    msg.type = pb.VDC_SEND_PUSH_NOTIFICATION
+    msg.vdc_send_push_notification.dSUID = str(self._vdsd.dsuid)
+    for elem in dict_to_elements(push_tree):
+        msg.vdc_send_push_notification.changedproperties.append(elem)
+
+    try:
+        await session.send_notification(msg)
+        logger.debug(
+            "ButtonInput[%d]: pushed settings for vdSD %s",
+            self._ds_index,
+            self._vdsd.dsuid,
+        )
+    except (ConnectionError, OSError) as exc:
+        logger.warning(
+            "ButtonInput[%d]: failed to push settings: %s",
+            self._ds_index,
+            exc,
+        )
+```
+
+### 6d — `SensorInput.push_settings()`
+
+**File:** `src/pydsvdcapi/sensor_input.py`
+
+Add after `_do_push` / `_on_deferred_push_fired` (~line 810). Follow the same pattern:
+
+```python
+async def push_settings(self, session: VdcSession | None = None) -> None:
+    """Push the current ``sensorSettings`` to the vdSM.
+
+    Sends a ``VDC_SEND_PUSH_NOTIFICATION`` carrying the full
+    ``sensorSettings`` subtree for this sensor input.  A no-op if no
+    session is active or the vdSD is not announced.
+    """
+    session = session or self._session
+    if session is None:
+        logger.debug(
+            "SensorInput[%d]: no active session — skipping push_settings",
+            self._ds_index,
+        )
+        return
+    if not self._vdsd.is_announced:
+        logger.debug(
+            "SensorInput[%d]: vdSD not announced — skipping push_settings",
+            self._ds_index,
+        )
+        return
+
+    settings_dict = self.get_settings_properties()
+    push_tree: dict[str, Any] = {
+        "sensorSettings": {str(self._ds_index): settings_dict}
+    }
+
+    msg = pb.Message()
+    msg.type = pb.VDC_SEND_PUSH_NOTIFICATION
+    msg.vdc_send_push_notification.dSUID = str(self._vdsd.dsuid)
+    for elem in dict_to_elements(push_tree):
+        msg.vdc_send_push_notification.changedproperties.append(elem)
+
+    try:
+        await session.send_notification(msg)
+        logger.debug(
+            "SensorInput[%d] '%s': pushed settings for vdSD %s",
+            self._ds_index,
+            self._name,
+            self._vdsd.dsuid,
+        )
+    except (ConnectionError, OSError) as exc:
+        logger.warning(
+            "SensorInput[%d] '%s': failed to push settings: %s",
+            self._ds_index,
+            self._name,
+            exc,
+        )
+```
+
+- [ ] **Step: After adding all four push_settings methods, run ruff + mypy + tests**
+
+```bash
+ruff check src/pydsvdcapi/output.py src/pydsvdcapi/binary_input.py src/pydsvdcapi/button_input.py src/pydsvdcapi/sensor_input.py
+mypy src/pydsvdcapi/output.py src/pydsvdcapi/binary_input.py src/pydsvdcapi/button_input.py src/pydsvdcapi/sensor_input.py
+pytest tests/ -x -q
+```
+
+- [ ] **Step: Commit all four push_settings methods**
+
+```bash
+git add src/pydsvdcapi/output.py src/pydsvdcapi/binary_input.py src/pydsvdcapi/button_input.py src/pydsvdcapi/sensor_input.py
+git commit -m "feat: add push_settings() to Output, BinaryInput, ButtonInput, SensorInput"
+```
+
+---
+
+## Task 7 — Export new types from `__init__.py`
+
+**Files:**
+- Modify: `src/pydsvdcapi/__init__.py`
+
+- [ ] **Step 1: Add new callback type names to `__all__`**
+
+In the `# Output` section of `__all__`, add after `"DimChannelCallback"`:
+
+```python
+"OutputSettingsChangedCallback",
+```
+
+In the `# Inputs` section, add:
+
+```python
+"BinaryInputSettingsChangedCallback",
+"ButtonInputSettingsChangedCallback",
+"SensorInputSettingsChangedCallback",
+```
+
+- [ ] **Step 2: Add import lines**
+
+In the `from pydsvdcapi.output import` block, add `OutputSettingsChangedCallback`.
+
+In the `from pydsvdcapi.binary_input import` block, add `BinaryInputSettingsChangedCallback`.
+
+In the `from pydsvdcapi.button_input import` block, add `ButtonInputSettingsChangedCallback`.
+
+In the `from pydsvdcapi.sensor_input import` block, add `SensorInputSettingsChangedCallback`.
+
+- [ ] **Step 3: Verify ruff**
+
+```bash
+ruff check src/pydsvdcapi/__init__.py
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/pydsvdcapi/__init__.py
+git commit -m "feat(__init__): export Settings*ChangedCallback type aliases"
+```
+
+---
+
+## Task 8 — Tests
+
+**Files:**
+- Create: `tests/test_settings_callbacks.py`
+
+Use the same test infrastructure pattern as `tests/test_binary_input.py` and `tests/test_output.py`: build a minimal `Vdc`/`Vdsd` from `VdcHost`, add a component, then exercise the callback and push paths.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/test_settings_callbacks.py` with these test cases:
+
+```python
+"""Tests for settings-changed callbacks and push_settings() on all component types."""
+
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+import pydsvdcapi as api
+from pydsvdcapi.binary_input import BinaryInput
+from pydsvdcapi.button_input import ButtonInput
+from pydsvdcapi.sensor_input import SensorInput
+from pydsvdcapi.output import Output
+from pydsvdcapi.enums import (
+    BinaryInputType,
+    BinaryInputUsage,
+    ButtonFunction,
+    ButtonGroup,
+    ButtonMode,
+    ButtonType,
+    OutputFunction,
+    SensorType,
+    SensorUsage,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_vdsd():
+    """Return a minimal Vdsd with a mock session."""
+    host = MagicMock()
+    host._store = None
+    host._session = None
+    vdc = api.Vdc(dsuid=api.DsUid.new_random(), name="test-vdc")
+    vdsd = api.Vdsd(dsuid=api.DsUid.new_random(), name="test-device", vdc=vdc)
+    vdsd._is_announced = True  # pretend announced
+    return vdsd
+
+
+def _make_session():
+    session = MagicMock()
+    session.send_notification = AsyncMock()
+    return session
+
+
+# ---------------------------------------------------------------------------
+# BinaryInput
+# ---------------------------------------------------------------------------
+
+class TestBinaryInputSettingsCallback:
+    def setup_method(self):
+        vdsd = _make_vdsd()
+        self.bi = vdsd.add_binary_input(
+            input_type=BinaryInputType.PRESENCE,
+            usage=BinaryInputUsage.ROOM,
+        )
+
+    @pytest.mark.asyncio
+    async def test_callback_fired_when_settings_change(self):
+        fired = []
+
+        async def cb(bi, changed):
+            fired.append((bi, changed))
+
+        self.bi.on_settings_changed = cb
+        self.bi.apply_settings({"group": 5})
+        # apply_settings is synchronous; callback invocation is the host's job.
+        # We test the callback by calling it directly as the host would.
+        if self.bi.on_settings_changed is not None:
+            await self.bi.on_settings_changed(self.bi, {"group": 5})
+
+        assert len(fired) == 1
+        bi_arg, changed = fired[0]
+        assert bi_arg is self.bi
+        assert changed == {"group": 5}
+
+    def test_callback_default_is_none(self):
+        assert self.bi.on_settings_changed is None
+
+    def test_callback_can_be_cleared(self):
+        async def cb(bi, changed): ...
+        self.bi.on_settings_changed = cb
+        self.bi.on_settings_changed = None
+        assert self.bi.on_settings_changed is None
+
+    @pytest.mark.asyncio
+    async def test_push_settings_no_session(self):
+        # Should not raise; just logs and returns.
+        self.bi._session = None
+        await self.bi.push_settings()  # no-op
+
+    @pytest.mark.asyncio
+    async def test_push_settings_sends_notification(self):
+        session = _make_session()
+        self.bi._session = session
+        await self.bi.push_settings()
+
+        session.send_notification.assert_awaited_once()
+        msg = session.send_notification.call_args[0][0]
+        # Decode changedproperties back to a dict to verify structure.
+        from pydsvdcapi.property_handling import elements_to_dict
+        props = elements_to_dict(list(msg.vdc_send_push_notification.changedproperties))
+        assert "binaryInputSettings" in props
+        bi_settings = props["binaryInputSettings"]
+        ds_idx_str = str(self.bi.ds_index)
+        assert ds_idx_str in bi_settings
+        # The settings dict must contain at least "group" and "sensorFunction".
+        inner = bi_settings[ds_idx_str]
+        assert "group" in inner
+        assert "sensorFunction" in inner
+
+
+# ---------------------------------------------------------------------------
+# ButtonInput
+# ---------------------------------------------------------------------------
+
+class TestButtonInputSettingsCallback:
+    def setup_method(self):
+        vdsd = _make_vdsd()
+        self.btn = vdsd.add_button_input(
+            button_type=ButtonType.SINGLE_01,
+            group=ButtonGroup.YELLOW,
+        )
+
+    @pytest.mark.asyncio
+    async def test_callback_fired(self):
+        fired = []
+        async def cb(btn, changed): fired.append(changed)
+        self.btn.on_settings_changed = cb
+        if self.btn.on_settings_changed:
+            await self.btn.on_settings_changed(self.btn, {"group": 1})
+        assert fired == [{"group": 1}]
+
+    def test_callback_default_is_none(self):
+        assert self.btn.on_settings_changed is None
+
+    @pytest.mark.asyncio
+    async def test_push_settings_no_session(self):
+        self.btn._session = None
+        await self.btn.push_settings()  # no-op
+
+    @pytest.mark.asyncio
+    async def test_push_settings_sends_notification(self):
+        session = _make_session()
+        self.btn._session = session
+        await self.btn.push_settings()
+
+        session.send_notification.assert_awaited_once()
+        msg = session.send_notification.call_args[0][0]
+        from pydsvdcapi.property_handling import elements_to_dict
+        props = elements_to_dict(list(msg.vdc_send_push_notification.changedproperties))
+        assert "buttonInputSettings" in props
+        inner = props["buttonInputSettings"][str(self.btn.ds_index)]
+        assert "group" in inner
+        assert "function" in inner
+        assert "mode" in inner
+
+
+# ---------------------------------------------------------------------------
+# SensorInput
+# ---------------------------------------------------------------------------
+
+class TestSensorInputSettingsCallback:
+    def setup_method(self):
+        vdsd = _make_vdsd()
+        self.si = vdsd.add_sensor_input(
+            sensor_type=SensorType.TEMPERATURE,
+            usage=SensorUsage.ROOM,
+        )
+
+    @pytest.mark.asyncio
+    async def test_callback_fired(self):
+        fired = []
+        async def cb(si, changed): fired.append(changed)
+        self.si.on_settings_changed = cb
+        if self.si.on_settings_changed:
+            await self.si.on_settings_changed(self.si, {"group": 2})
+        assert fired == [{"group": 2}]
+
+    def test_callback_default_is_none(self):
+        assert self.si.on_settings_changed is None
+
+    @pytest.mark.asyncio
+    async def test_push_settings_no_session(self):
+        self.si._session = None
+        await self.si.push_settings()  # no-op
+
+    @pytest.mark.asyncio
+    async def test_push_settings_sends_notification(self):
+        session = _make_session()
+        self.si._session = session
+        await self.si.push_settings()
+
+        session.send_notification.assert_awaited_once()
+        msg = session.send_notification.call_args[0][0]
+        from pydsvdcapi.property_handling import elements_to_dict
+        props = elements_to_dict(list(msg.vdc_send_push_notification.changedproperties))
+        assert "sensorSettings" in props
+        inner = props["sensorSettings"][str(self.si.ds_index)]
+        assert "group" in inner
+        assert "minPushInterval" in inner
+        assert "changesOnlyInterval" in inner
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+class TestOutputSettingsCallback:
+    def setup_method(self):
+        vdsd = _make_vdsd()
+        self.output = vdsd.add_output(function=OutputFunction.DIMMER)
+
+    @pytest.mark.asyncio
+    async def test_callback_fired(self):
+        fired = []
+        async def cb(out, changed): fired.append(changed)
+        self.output.on_settings_changed = cb
+        if self.output.on_settings_changed:
+            await self.output.on_settings_changed(self.output, {"mode": 1})
+        assert fired == [{"mode": 1}]
+
+    def test_callback_default_is_none(self):
+        assert self.output.on_settings_changed is None
+
+    @pytest.mark.asyncio
+    async def test_push_settings_no_session(self):
+        self.output._session = None
+        await self.output.push_settings()  # no-op
+
+    @pytest.mark.asyncio
+    async def test_push_settings_sends_notification(self):
+        session = _make_session()
+        self.output._session = session
+        await self.output.push_settings()
+
+        session.send_notification.assert_awaited_once()
+        msg = session.send_notification.call_args[0][0]
+        from pydsvdcapi.property_handling import elements_to_dict
+        props = elements_to_dict(list(msg.vdc_send_push_notification.changedproperties))
+        assert "outputSettings" in props
+        inner = props["outputSettings"]
+        assert "mode" in inner
+
+
+# ---------------------------------------------------------------------------
+# __init__ exports
+# ---------------------------------------------------------------------------
+
+def test_callback_types_exported():
+    assert hasattr(api, "OutputSettingsChangedCallback")
+    assert hasattr(api, "BinaryInputSettingsChangedCallback")
+    assert hasattr(api, "ButtonInputSettingsChangedCallback")
+    assert hasattr(api, "SensorInputSettingsChangedCallback")
+```
+
+- [ ] **Step 2: Run tests to verify they fail before implementation (TDD baseline)**
+
+```bash
+pytest tests/test_settings_callbacks.py -v
+```
+
+Expected: `AttributeError` / `ImportError` failures because the new types don't exist yet.
+
+- [ ] **Step 3: After all Tasks 1–7 are complete, run tests again**
+
+```bash
+pytest tests/test_settings_callbacks.py -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Run full test suite**
+
+```bash
+pytest tests/ -q
+```
+
+Expected: all tests pass (no regressions).
+
+- [ ] **Step 5: Commit tests**
+
+```bash
+git add tests/test_settings_callbacks.py
+git commit -m "test: add tests for settings callbacks and push_settings()"
+```
+
+---
+
+## Task 9 — Final lint + type check pass
+
+- [ ] **Step 1: ruff check across all modified files**
+
+```bash
+ruff check src/pydsvdcapi/output.py src/pydsvdcapi/binary_input.py \
+  src/pydsvdcapi/button_input.py src/pydsvdcapi/sensor_input.py \
+  src/pydsvdcapi/vdc_host.py src/pydsvdcapi/__init__.py \
+  tests/test_settings_callbacks.py
+```
+
+Expected: no errors.
+
+- [ ] **Step 2: mypy check across all modified source files**
+
+```bash
+mypy src/pydsvdcapi/output.py src/pydsvdcapi/binary_input.py \
+  src/pydsvdcapi/button_input.py src/pydsvdcapi/sensor_input.py \
+  src/pydsvdcapi/vdc_host.py src/pydsvdcapi/__init__.py
+```
+
+Expected: no errors.
+
+- [ ] **Step 3: Full test suite one more time**
+
+```bash
+pytest tests/ -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Final commit (if any lint fixes were needed)**
+
+```bash
+git add -p  # stage only the lint fixes
+git commit -m "fix: ruff/mypy cleanup for settings callbacks feature"
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pydsvdcapi"
-version = "0.8.8"
+version = "0.8.9"
 description = "Python library for the digitalSTROM vDC API"
 readme = "README.md"
 license = { file = "LICENSE" }

--- a/src/pydsvdcapi/__init__.py
+++ b/src/pydsvdcapi/__init__.py
@@ -102,10 +102,13 @@ __all__ = [
     "StandardAction",
     # Inputs
     "BinaryInput",
+    "BinaryInputSettingsChangedCallback",
     "BUTTON_TYPE_ELEMENTS",
     "ButtonInput",
+    "ButtonInputSettingsChangedCallback",
     "ClickDetector",
     "SensorInput",
+    "SensorInputSettingsChangedCallback",
     "create_button_group",
     "get_required_elements",
     # Events / States / Properties
@@ -118,6 +121,7 @@ __all__ = [
     "DeviceProperty",
     # Output
     "DimChannelCallback",
+    "OutputSettingsChangedCallback",
     "FUNCTION_CHANNELS",
     "Output",
     "CHANNEL_SPECS",
@@ -151,10 +155,14 @@ from pydsvdcapi.addons.converter import (  # noqa: F401
     apply_converter,
     compile_converter,
 )
-from pydsvdcapi.binary_input import BinaryInput  # noqa: F401
+from pydsvdcapi.binary_input import (  # noqa: F401
+    BinaryInput,
+    BinaryInputSettingsChangedCallback,
+)
 from pydsvdcapi.button_input import (  # noqa: F401
     BUTTON_TYPE_ELEMENTS,
     ButtonInput,
+    ButtonInputSettingsChangedCallback,
     ClickDetector,
     create_button_group,
     get_required_elements,
@@ -239,6 +247,7 @@ from pydsvdcapi.output import (  # noqa: F401
     FUNCTION_CHANNELS,
     DimChannelCallback,
     Output,
+    OutputSettingsChangedCallback,
 )
 from pydsvdcapi.output_channel import (  # noqa: F401
     CHANNEL_SPECS,
@@ -255,7 +264,10 @@ from pydsvdcapi.property_handling import (  # noqa: F401
     expand_setproperty_wildcards,
     match_query,
 )
-from pydsvdcapi.sensor_input import SensorInput  # noqa: F401
+from pydsvdcapi.sensor_input import (  # noqa: F401
+    SensorInput,
+    SensorInputSettingsChangedCallback,
+)
 from pydsvdcapi.session import (  # noqa: F401
     SUPPORTED_API_VERSION,
     HelloCallback,

--- a/src/pydsvdcapi/__init__.py
+++ b/src/pydsvdcapi/__init__.py
@@ -1,6 +1,6 @@
 """pydsvdcapi - Python library for the DSvDC API."""
 
-__version__ = "0.8.8"
+__version__ = "0.8.9"
 
 __all__ = [
     # Version

--- a/src/pydsvdcapi/binary_input.py
+++ b/src/pydsvdcapi/binary_input.py
@@ -472,7 +472,9 @@ class BinaryInput:
         return self._on_settings_changed
 
     @on_settings_changed.setter
-    def on_settings_changed(self, callback: BinaryInputSettingsChangedCallback | None) -> None:
+    def on_settings_changed(
+        self, callback: BinaryInputSettingsChangedCallback | None
+    ) -> None:
         self._on_settings_changed = callback
 
     # ---- persistence -------------------------------------------------

--- a/src/pydsvdcapi/binary_input.py
+++ b/src/pydsvdcapi/binary_input.py
@@ -50,7 +50,7 @@ from __future__ import annotations
 
 import logging
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Coroutine
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -74,6 +74,13 @@ logger = logging.getLogger(__name__)
 #: Input type identifiers for the ``inputType`` description property.
 INPUT_TYPE_POLL_ONLY: int = 0
 INPUT_TYPE_DETECTS_CHANGES: int = 1
+
+#: Type alias for the binary-input-settings-changed callback.
+#: ``async def callback(binary_input: BinaryInput, changed: dict[str, Any]) -> None``
+BinaryInputSettingsChangedCallback = Callable[
+    ["BinaryInput", dict[str, Any]],
+    Coroutine[Any, Any, None],
+]
 
 
 # ---------------------------------------------------------------------------
@@ -149,6 +156,7 @@ class BinaryInput:
 
         # ---- session (stored by start_alive_timer for push fallback) -
         self._session: VdcSession | None = None
+        self._on_settings_changed: BinaryInputSettingsChangedCallback | None = None
 
         # ---- value converter (optional, persisted) -------------------
         self._uplink_converter_code: str | None = None
@@ -457,6 +465,15 @@ class BinaryInput:
                 self._sensor_function.name,
             )
             self._schedule_auto_save()
+
+    @property
+    def on_settings_changed(self) -> BinaryInputSettingsChangedCallback | None:
+        """Callback invoked when the vdSM writes ``binaryInputSettings``."""
+        return self._on_settings_changed
+
+    @on_settings_changed.setter
+    def on_settings_changed(self, callback: BinaryInputSettingsChangedCallback | None) -> None:
+        self._on_settings_changed = callback
 
     # ---- persistence -------------------------------------------------
 

--- a/src/pydsvdcapi/binary_input.py
+++ b/src/pydsvdcapi/binary_input.py
@@ -586,6 +586,54 @@ class BinaryInput:
                 exc,
             )
 
+    async def push_settings(self, session: VdcSession | None = None) -> None:
+        """Push the current ``binaryInputSettings`` to the vdSM.
+
+        Sends a ``VDC_SEND_PUSH_NOTIFICATION`` carrying the full
+        ``binaryInputSettings`` subtree for this input.  A no-op if no
+        session is active or the vdSD is not announced.
+        """
+        session = session or self._session
+        if session is None:
+            logger.debug(
+                "BinaryInput[%d]: no active session — skipping push_settings",
+                self._ds_index,
+            )
+            return
+        if not self._vdsd.is_announced:
+            logger.debug(
+                "BinaryInput[%d]: vdSD not announced — skipping push_settings",
+                self._ds_index,
+            )
+            return
+
+        settings_dict = self.get_settings_properties()
+        push_tree: dict[str, Any] = {
+            "binaryInputSettings": {str(self._ds_index): settings_dict}
+        }
+
+        msg = pb.Message()
+        msg.type = pb.VDC_SEND_PUSH_NOTIFICATION
+        msg.vdc_send_push_notification.dSUID = str(self._vdsd.dsuid)
+        for elem in dict_to_elements(push_tree):
+            msg.vdc_send_push_notification.changedproperties.append(elem)
+
+        try:
+            await session.send_notification(msg)
+            logger.debug(
+                "BinaryInput[%d] '%s': pushed settings for vdSD %s",
+                self._ds_index,
+                self._name,
+                self._vdsd.dsuid,
+            )
+        except (ConnectionError, OSError) as exc:
+            logger.warning(
+                "BinaryInput[%d] '%s': failed to push settings: %s",
+                self._ds_index,
+                self._name,
+                exc,
+            )
+
     # ---- session management ------------------------------------------
 
     def start_alive_timer(self, session: VdcSession) -> None:

--- a/src/pydsvdcapi/button_input.py
+++ b/src/pydsvdcapi/button_input.py
@@ -1188,6 +1188,52 @@ class ButtonInput:
                 exc,
             )
 
+    async def push_settings(self, session: VdcSession | None = None) -> None:
+        """Push the current ``buttonInputSettings`` to the vdSM.
+
+        Sends a ``VDC_SEND_PUSH_NOTIFICATION`` carrying the full
+        ``buttonInputSettings`` subtree for this input.  A no-op if no
+        session is active or the vdSD is not announced.
+        """
+        session = session or self._session
+        if session is None:
+            logger.debug(
+                "ButtonInput[%d]: no active session — skipping push_settings",
+                self._ds_index,
+            )
+            return
+        if not self._vdsd.is_announced:
+            logger.debug(
+                "ButtonInput[%d]: vdSD not announced — skipping push_settings",
+                self._ds_index,
+            )
+            return
+
+        settings_dict = self.get_settings_properties()
+        push_tree: dict[str, Any] = {
+            "buttonInputSettings": {str(self._ds_index): settings_dict}
+        }
+
+        msg = pb.Message()
+        msg.type = pb.VDC_SEND_PUSH_NOTIFICATION
+        msg.vdc_send_push_notification.dSUID = str(self._vdsd.dsuid)
+        for elem in dict_to_elements(push_tree):
+            msg.vdc_send_push_notification.changedproperties.append(elem)
+
+        try:
+            await session.send_notification(msg)
+            logger.debug(
+                "ButtonInput[%d]: pushed settings for vdSD %s",
+                self._ds_index,
+                self._vdsd.dsuid,
+            )
+        except (ConnectionError, OSError) as exc:
+            logger.warning(
+                "ButtonInput[%d]: failed to push settings: %s",
+                self._ds_index,
+                exc,
+            )
+
     # ---- session management ------------------------------------------
     #
     #  Buttons do NOT have alive timers.  These methods follow the

--- a/src/pydsvdcapi/button_input.py
+++ b/src/pydsvdcapi/button_input.py
@@ -1068,7 +1068,9 @@ class ButtonInput:
         return self._on_settings_changed
 
     @on_settings_changed.setter
-    def on_settings_changed(self, callback: ButtonInputSettingsChangedCallback | None) -> None:
+    def on_settings_changed(
+        self, callback: ButtonInputSettingsChangedCallback | None
+    ) -> None:
         self._on_settings_changed = callback
 
     # ---- persistence -------------------------------------------------

--- a/src/pydsvdcapi/button_input.py
+++ b/src/pydsvdcapi/button_input.py
@@ -111,7 +111,7 @@ import asyncio
 import enum
 import logging
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Coroutine
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -198,6 +198,18 @@ DEFAULT_MULTI_CLICK_WINDOW: float = 0.3
 
 #: Interval between ``HOLD_REPEAT`` events while button is held.
 DEFAULT_HOLD_REPEAT_INTERVAL: float = 1.0
+
+
+# ---------------------------------------------------------------------------
+# Type aliases
+# ---------------------------------------------------------------------------
+
+#: Type alias for the button-input-settings-changed callback.
+#: ``async def callback(button_input: ButtonInput, changed: dict[str, Any]) -> None``
+ButtonInputSettingsChangedCallback = Callable[
+    ["ButtonInput", dict[str, Any]],
+    Coroutine[Any, Any, None],
+]
 
 
 # ---------------------------------------------------------------------------
@@ -619,6 +631,7 @@ class ButtonInput:
 
         # ---- session reference (set on announcement) -----------------
         self._session: VdcSession | None = None
+        self._on_settings_changed: ButtonInputSettingsChangedCallback | None = None
 
         # ---- click detector (state machine) --------------------------
         valid_keys = {
@@ -1048,6 +1061,15 @@ class ButtonInput:
                 self._channel,
             )
             self._schedule_auto_save()
+
+    @property
+    def on_settings_changed(self) -> ButtonInputSettingsChangedCallback | None:
+        """Callback invoked when the vdSM writes ``buttonInputSettings``."""
+        return self._on_settings_changed
+
+    @on_settings_changed.setter
+    def on_settings_changed(self, callback: ButtonInputSettingsChangedCallback | None) -> None:
+        self._on_settings_changed = callback
 
     # ---- persistence -------------------------------------------------
 

--- a/src/pydsvdcapi/output.py
+++ b/src/pydsvdcapi/output.py
@@ -1028,7 +1028,9 @@ class Output:
         return self._on_settings_changed
 
     @on_settings_changed.setter
-    def on_settings_changed(self, callback: OutputSettingsChangedCallback | None) -> None:
+    def on_settings_changed(
+        self, callback: OutputSettingsChangedCallback | None
+    ) -> None:
         self._on_settings_changed = callback
 
     def add_channel(

--- a/src/pydsvdcapi/output.py
+++ b/src/pydsvdcapi/output.py
@@ -1813,9 +1813,7 @@ class Output:
         if self._active_group is not None:
             settings["activeGroup"] = self._active_group
 
-        # Groups — emit all 64 IDs (p44vdc behaviour: true for members, false
-        # for non-members) so the vdSM sees the full group-membership bitmap.
-        settings["groups"] = {str(gid): (gid in self._groups) for gid in range(64)}
+        settings["groups"] = {str(gid): True for gid in sorted(self._groups)}
 
         pg = (
             int(self._vdsd.primary_group) if self._vdsd.primary_group is not None else 0

--- a/src/pydsvdcapi/output.py
+++ b/src/pydsvdcapi/output.py
@@ -1671,6 +1671,50 @@ class Output:
                 exc,
             )
 
+    async def push_settings(self) -> None:
+        """Push the current ``outputSettings`` to the vdSM.
+
+        Sends a ``VDC_SEND_PUSH_NOTIFICATION`` with the full
+        ``outputSettings`` property subtree.  A no-op if the session is
+        not active or the vdSD has not been announced.
+        """
+        session = self._session
+        if session is None:
+            logger.debug(
+                "No active session — skipping push_settings for output '%s'",
+                self._name,
+            )
+            return
+        if not self._vdsd.is_announced:
+            logger.debug(
+                "vdSD not announced — skipping push_settings for output '%s'",
+                self._name,
+            )
+            return
+
+        settings_dict = self.get_settings_properties()
+        push_tree: dict[str, Any] = {"outputSettings": settings_dict}
+
+        msg = pb.Message()
+        msg.type = pb.VDC_SEND_PUSH_NOTIFICATION
+        msg.vdc_send_push_notification.dSUID = str(self._vdsd.dsuid)
+        for elem in dict_to_elements(push_tree):
+            msg.vdc_send_push_notification.changedproperties.append(elem)
+
+        try:
+            await session.send_notification(msg)
+            logger.debug(
+                "Pushed outputSettings for vdSD %s: %s",
+                self._vdsd.dsuid,
+                settings_dict,
+            )
+        except (ConnectionError, OSError) as exc:
+            logger.warning(
+                "Failed to push outputSettings for vdSD %s: %s",
+                self._vdsd.dsuid,
+                exc,
+            )
+
     # ==================================================================
     # Channel property dicts (for getProperty responses)
     # ==================================================================

--- a/src/pydsvdcapi/output.py
+++ b/src/pydsvdcapi/output.py
@@ -119,6 +119,14 @@ DimChannelCallback = Callable[
     Coroutine[Any, Any, None],
 ]
 
+#: Type alias for the output-settings-changed callback.
+#: ``async def callback(output: Output, changed: dict[str, Any]) -> None``
+#: *changed* is the dict of keys that arrived in the ``setProperty`` request.
+OutputSettingsChangedCallback = Callable[
+    ["Output", dict[str, Any]],
+    Coroutine[Any, Any, None],
+]
+
 
 # ---------------------------------------------------------------------------
 # Output function → auto-created channel types
@@ -664,6 +672,8 @@ class Output:
         self._on_channel_applied: ChannelAppliedCallback | None = None
         #: Callback invoked for dimChannel notifications (§7.3.5).
         self._on_dim_channel: DimChannelCallback | None = None
+        #: Callback invoked when vdSM writes outputSettings.
+        self._on_settings_changed: OutputSettingsChangedCallback | None = None
         #: Last stepping direction for AREA_STEPPING_CONTINUE: -1 down, +1 up, 0 unknown.
         self._last_step_direction: int = 0
         #: Area of last directional step (for AREA_STEPPING_CONTINUE).
@@ -1011,6 +1021,15 @@ class Output:
     @on_dim_channel.setter
     def on_dim_channel(self, callback: DimChannelCallback | None) -> None:
         self._on_dim_channel = callback
+
+    @property
+    def on_settings_changed(self) -> OutputSettingsChangedCallback | None:
+        """Callback invoked when the vdSM writes ``outputSettings``."""
+        return self._on_settings_changed
+
+    @on_settings_changed.setter
+    def on_settings_changed(self, callback: OutputSettingsChangedCallback | None) -> None:
+        self._on_settings_changed = callback
 
     def add_channel(
         self,

--- a/src/pydsvdcapi/output.py
+++ b/src/pydsvdcapi/output.py
@@ -1021,6 +1021,9 @@ class Output:
         min_value: float | None = None,
         max_value: float | None = None,
         resolution: float | None = None,
+        siunit: str | None = None,
+        symbol: str | None = None,
+        enum_values: dict[int, str] | None = None,
     ) -> OutputChannel:
         """Add a channel to this output.
 
@@ -1032,6 +1035,9 @@ class Output:
             Zero-based index.  Auto-assigned (next free) if omitted.
         name, min_value, max_value, resolution:
             Override defaults from :data:`CHANNEL_SPECS`.
+        siunit, symbol, enum_values:
+            Unit metadata and discrete value mapping for custom channel
+            types.  Ignored for predefined types (spec values are used).
 
         Returns
         -------
@@ -1058,6 +1064,9 @@ class Output:
             min_value=min_value,
             max_value=max_value,
             resolution=resolution,
+            siunit=siunit,
+            symbol=symbol,
+            enum_values=enum_values,
         )
         self._channels[ds_index] = channel
         self._ensure_scene_channel_entries()

--- a/src/pydsvdcapi/output_channel.py
+++ b/src/pydsvdcapi/output_channel.py
@@ -418,14 +418,28 @@ class OutputChannel:
         Zero-based ``dsIndex`` within the device.  Index 0 is the
         default / primary channel.
     name:
-        Human-readable label.  Defaults to the spec name for the
-        channel type, or ``"channel_<dsIndex>"`` for custom types.
+        Protocol-level channel name.  Defaults to the spec name for
+        predefined types, or ``"channel_<dsIndex>"`` for custom types.
+        Ignored for predefined types when *name* matches the spec name;
+        callers may supply a custom label for predefined types if
+        needed, but the spec name is strongly preferred.
     min_value:
         Override the standard minimum value.
     max_value:
         Override the standard maximum value.
     resolution:
         Override the standard resolution.
+    siunit:
+        SI unit name (e.g. ``"percent"``, ``"kelvin"``).  Only used for
+        custom channel types — predefined types always use the spec value.
+    symbol:
+        Unit symbol (e.g. ``"%"``, ``"K"``).  Only used for custom
+        channel types — predefined types always use the spec value.
+    enum_values:
+        Discrete value mapping ``{int: str}`` for enum/mode channels
+        (e.g. ``{0: "off", 1: "on"}``).  Only used for custom channel
+        types — predefined types always use the spec value.  When set,
+        emitted as the ``values`` container in ``channelDescriptions``.
     """
 
     def __init__(
@@ -438,6 +452,9 @@ class OutputChannel:
         min_value: float | None = None,
         max_value: float | None = None,
         resolution: float | None = None,
+        siunit: str | None = None,
+        symbol: str | None = None,
+        enum_values: dict[int, str] | None = None,
     ) -> None:
         self._output: Output = output
 
@@ -474,6 +491,17 @@ class OutputChannel:
         self._resolution: float = float(
             resolution if resolution is not None else (spec.resolution if spec else 1.0)
         )
+
+        # Predefined channels: spec is authoritative for unit/symbol/values.
+        # Custom channels: use caller-supplied values.
+        if spec is not None:
+            self._siunit: str = spec.siunit
+            self._symbol: str = spec.symbol
+            self._enum_values: dict[int, str] | None = spec.enum_values
+        else:
+            self._siunit = siunit or ""
+            self._symbol = symbol or ""
+            self._enum_values = enum_values
 
         # ---- volatile state (NOT persisted) --------------------------
         self._value: float | None = None
@@ -726,7 +754,6 @@ class OutputChannel:
         the channel's :attr:`name` inside the ``channelDescriptions`` property
         sub-tree (§4.9.1).  Keys match the vDC API property names.
         """
-        spec = get_channel_spec(self._channel_type)
         props: dict[str, Any] = {
             "name": self._name,
             "channelType": int(self._channel_type),
@@ -735,12 +762,12 @@ class OutputChannel:
             "max": self._max_value,
             "resolution": self._resolution,
         }
-        if spec is not None and spec.siunit:
-            props["siunit"] = spec.siunit
-        if spec is not None and spec.symbol:
-            props["symbol"] = spec.symbol
-        if spec is not None and spec.enum_values is not None:
-            props["values"] = {str(k): v for k, v in spec.enum_values.items()}
+        if self._siunit:
+            props["siunit"] = self._siunit
+        if self._symbol:
+            props["symbol"] = self._symbol
+        if self._enum_values is not None:
+            props["values"] = {str(k): v for k, v in self._enum_values.items()}
         return props
 
     def get_settings_properties(self) -> dict[str, Any]:
@@ -782,6 +809,12 @@ class OutputChannel:
             "max": self._max_value,
             "resolution": self._resolution,
         }
+        if self._siunit:
+            node["siunit"] = self._siunit
+        if self._symbol:
+            node["symbol"] = self._symbol
+        if self._enum_values is not None:
+            node["enumValues"] = {str(k): v for k, v in self._enum_values.items()}
         if self._uplink_converter_code is not None:
             node["uplinkConverter"] = self._uplink_converter_code
         if self._downlink_converter_code is not None:
@@ -817,6 +850,12 @@ class OutputChannel:
             self._max_value = float(state["max"])
         if "resolution" in state:
             self._resolution = float(state["resolution"])
+        if "siunit" in state:
+            self._siunit = str(state["siunit"])
+        if "symbol" in state:
+            self._symbol = str(state["symbol"])
+        if "enumValues" in state:
+            self._enum_values = {int(k): str(v) for k, v in state["enumValues"].items()}
         # Converters
         if "uplinkConverter" in state:
             self.set_uplink_converter(state["uplinkConverter"])

--- a/src/pydsvdcapi/sensor_input.py
+++ b/src/pydsvdcapi/sensor_input.py
@@ -798,6 +798,54 @@ class SensorInput:
         # (Re-)schedule the alive timer after every push attempt.
         self._reschedule_alive_timer()
 
+    async def push_settings(self, session: VdcSession | None = None) -> None:
+        """Push the current ``sensorSettings`` to the vdSM.
+
+        Sends a ``VDC_SEND_PUSH_NOTIFICATION`` carrying the full
+        ``sensorSettings`` subtree for this sensor input.  A no-op if no
+        session is active or the vdSD is not announced.
+        """
+        session = session or self._session
+        if session is None:
+            logger.debug(
+                "SensorInput[%d]: no active session — skipping push_settings",
+                self._ds_index,
+            )
+            return
+        if not self._vdsd.is_announced:
+            logger.debug(
+                "SensorInput[%d]: vdSD not announced — skipping push_settings",
+                self._ds_index,
+            )
+            return
+
+        settings_dict = self.get_settings_properties()
+        push_tree: dict[str, Any] = {
+            "sensorSettings": {str(self._ds_index): settings_dict}
+        }
+
+        msg = pb.Message()
+        msg.type = pb.VDC_SEND_PUSH_NOTIFICATION
+        msg.vdc_send_push_notification.dSUID = str(self._vdsd.dsuid)
+        for elem in dict_to_elements(push_tree):
+            msg.vdc_send_push_notification.changedproperties.append(elem)
+
+        try:
+            await session.send_notification(msg)
+            logger.debug(
+                "SensorInput[%d] '%s': pushed settings for vdSD %s",
+                self._ds_index,
+                self._name,
+                self._vdsd.dsuid,
+            )
+        except (ConnectionError, OSError) as exc:
+            logger.warning(
+                "SensorInput[%d] '%s': failed to push settings: %s",
+                self._ds_index,
+                self._name,
+                exc,
+            )
+
     # ---- deferred push (minPushInterval rate limiting) ---------------
 
     def _schedule_deferred_push(self, session: VdcSession, delay: float) -> None:

--- a/src/pydsvdcapi/sensor_input.py
+++ b/src/pydsvdcapi/sensor_input.py
@@ -75,7 +75,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from collections.abc import Callable
+from collections.abc import Callable, Coroutine
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -97,6 +97,17 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+
+# ---------------------------------------------------------------------------
+# Type aliases
+# ---------------------------------------------------------------------------
+
+#: Type alias for the sensor-input-settings-changed callback.
+#: ``async def callback(sensor_input: SensorInput, changed: dict[str, Any]) -> None``
+SensorInputSettingsChangedCallback = Callable[
+    ["SensorInput", dict[str, Any]],
+    Coroutine[Any, Any, None],
+]
 
 # ---------------------------------------------------------------------------
 # SensorInput
@@ -233,6 +244,7 @@ class SensorInput:
 
         # ---- push throttling / alive timer state ---------------------
         self._session: VdcSession | None = None
+        self._on_settings_changed: SensorInputSettingsChangedCallback | None = None
         self._last_push_time: float | None = None
         self._last_pushed_state: tuple | None = None
         self._alive_timer_handle: asyncio.TimerHandle | None = None
@@ -600,6 +612,15 @@ class SensorInput:
                 self._changes_only_interval,
             )
             self._schedule_auto_save()
+
+    @property
+    def on_settings_changed(self) -> SensorInputSettingsChangedCallback | None:
+        """Callback invoked when the vdSM writes ``sensorSettings``."""
+        return self._on_settings_changed
+
+    @on_settings_changed.setter
+    def on_settings_changed(self, callback: SensorInputSettingsChangedCallback | None) -> None:
+        self._on_settings_changed = callback
 
     # ---- persistence -------------------------------------------------
 

--- a/src/pydsvdcapi/sensor_input.py
+++ b/src/pydsvdcapi/sensor_input.py
@@ -619,7 +619,9 @@ class SensorInput:
         return self._on_settings_changed
 
     @on_settings_changed.setter
-    def on_settings_changed(self, callback: SensorInputSettingsChangedCallback | None) -> None:
+    def on_settings_changed(
+        self, callback: SensorInputSettingsChangedCallback | None
+    ) -> None:
         self._on_settings_changed = callback
 
     # ---- persistence -------------------------------------------------

--- a/src/pydsvdcapi/vdc_host.py
+++ b/src/pydsvdcapi/vdc_host.py
@@ -247,7 +247,7 @@ class VdcHost:
         self,
         *,
         mac: str | None = None,
-        port: int = DEFAULT_VDC_PORT,
+        port: int | None = None,
         dsuid: DsUid | None = None,
         name: str | None = None,
         model: str = "pydsvdcapi vDC host",
@@ -277,8 +277,9 @@ class VdcHost:
 
         # --- network --------------------------------------------------
         self._mac: str = mac or host_state.get("mac") or _get_default_mac()
+        # Explicit port wins; otherwise restore from saved state; fall back to default.
         self._port: int = (
-            port if port != DEFAULT_VDC_PORT else host_state.get("port", port)
+            port if port is not None else host_state.get("port", DEFAULT_VDC_PORT)
         )
 
         # --- identity -------------------------------------------------
@@ -331,7 +332,7 @@ class VdcHost:
         # --- TCP server / session state --------------------------------
         self._server: asyncio.AbstractServer | None = None
         self._session: VdcSession | None = None
-        self._session_task: asyncio.Task | None = None
+        self._reannounce_task: asyncio.Task | None = None
         self._on_message: MessageCallback | None = None
         self._on_remove: RemoveCallback | None = None
         self._on_identify: IdentifyCallback | None = None
@@ -791,8 +792,10 @@ class VdcHost:
                 pass
 
         browser = AsyncServiceBrowser(zc.zeroconf, VDC_SERVICE_TYPE, _Listener())
-        await asyncio.sleep(1.0)
-        await browser.async_cancel()
+        try:
+            await asyncio.sleep(1.0)
+        finally:
+            await browser.async_cancel()
 
         for name in discovered_names:
             info = AsyncServiceInfo(VDC_SERVICE_TYPE, name)
@@ -844,8 +847,14 @@ class VdcHost:
         )
 
         self._zeroconf = AsyncZeroconf()
-        await self._evict_stale_vdc_entries(self._zeroconf)
-        await self._zeroconf.async_register_service(self._service_info)
+        try:
+            await self._evict_stale_vdc_entries(self._zeroconf)
+            await self._zeroconf.async_register_service(self._service_info)
+        except Exception:
+            await self._zeroconf.async_close()
+            self._zeroconf = None
+            self._service_info = None
+            raise
         logger.info(
             "Announced vDC host '%s' on port %d (dSUID %s)",
             service_name,
@@ -990,6 +999,11 @@ class VdcHost:
         # Flush any pending auto-save so no property changes are lost.
         self.flush()
 
+        # Cancel any in-flight re-announce task so it cannot race with shutdown.
+        if self._reannounce_task is not None and not self._reannounce_task.done():
+            self._reannounce_task.cancel()
+            self._reannounce_task = None
+
         # Unannounce the DNS-SD service *before* dropping the TCP
         # connection.  This gives the vdSM's Avahi watcher a chance to
         # notice the service is gone so it does not immediately attempt
@@ -1059,7 +1073,6 @@ class VdcHost:
         finally:
             if self._session is session:
                 self._session = None
-                self._session_task = None
             # Reset announcement state for all vDCs so they will be
             # re-announced on the next session.
             for vdc in self._vdcs.values():
@@ -1068,7 +1081,7 @@ class VdcHost:
             if not self._stopping:
                 # Trigger re-announcement in background so vdSM can rediscover
                 # and reconnect to this host after a session ends unexpectedly.
-                asyncio.create_task(
+                self._reannounce_task = asyncio.create_task(
                     self._reannounce_after_disconnect(),
                     name="vdc-reannounce",
                 )
@@ -1084,16 +1097,20 @@ class VdcHost:
         A brief pause followed by an unannounce/announce cycle makes the
         vdSM see the service as new, prompting it to reconnect.
         """
-        await asyncio.sleep(5.0)
-        if self._stopping:
-            return
         try:
+            await asyncio.sleep(5.0)
+            if self._stopping:
+                return
             logger.info("Re-announcing after session disconnect")
             await self.unannounce()
             await asyncio.sleep(1.0)
             await self.announce()
+        except asyncio.CancelledError:
+            pass
         except Exception:  # noqa: BLE001
             logger.exception("Re-announce after disconnect failed")
+        finally:
+            self._reannounce_task = None
 
     async def _close_session(self) -> None:
         """Close the active session if there is one."""
@@ -1101,7 +1118,6 @@ class VdcHost:
             logger.info("Closing existing session with %s", self._session.vdsm_dsuid)
             await self._session.close()
             self._session = None
-            self._session_task = None
 
     async def _flush_pending_vanish(self, session: VdcSession) -> None:
         """Send VDC_SEND_VANISH for every dSUID in _pending_vanish, then clear.
@@ -1179,7 +1195,7 @@ class VdcHost:
             return self._handle_get_property(msg)
 
         if msg_type == pb.VDSM_REQUEST_SET_PROPERTY:
-            return self._handle_set_property(msg)
+            return await self._handle_set_property(msg)
 
         if msg_type == pb.VDSM_NOTIFICATION_SET_OUTPUT_CHANNEL_VALUE:
             await self._handle_set_output_channel_value(session, msg)
@@ -1229,8 +1245,8 @@ class VdcHost:
         return None
 
     def _resolve_entity(self, dsuid_str: str) -> dict[str, Any] | None:
-        """Return ``(properties_dict, entity)`` for the entity with
-        the given dSUID string, or ``None`` if not found."""
+        """Return the property dict for the entity with the given dSUID,
+        or ``None`` if no matching host / vDC / vdSD is found."""
         # Normalise to upper-case — the vdSM may send lower-case hex.
         dsuid_str = dsuid_str.upper()
         if dsuid_str == str(self._dsuid):
@@ -1323,7 +1339,7 @@ class VdcHost:
 
         return resp
 
-    def _handle_set_property(self, msg: pb.Message) -> pb.Message:
+    async def _handle_set_property(self, msg: pb.Message) -> pb.Message:
         """Handle a ``VDSM_REQUEST_SET_PROPERTY``."""
         # Normalise to upper-case — the vdSM may send lower-case hex.
         target_dsuid = msg.vdsm_request_set_property.dSUID.upper()
@@ -1354,7 +1370,7 @@ class VdcHost:
         for vdc in self._vdcs.values():
             vdsd = vdc.get_vdsd_by_dsuid(DsUid.from_string(target_dsuid))
             if vdsd is not None:
-                self._apply_vdsd_set_property(vdsd, incoming)
+                await self._apply_vdsd_set_property(vdsd, incoming)
                 resp.generic_response.code = pb.ERR_OK
                 return resp
 
@@ -1377,7 +1393,7 @@ class VdcHost:
             vdc.zone_id = int(incoming["zoneID"])
             logger.info("vDC '%s' zoneID set to %d", vdc.dsuid, vdc.zone_id)
 
-    def _apply_vdsd_set_property(self, vdsd: Any, incoming: dict[str, Any]) -> None:
+    async def _apply_vdsd_set_property(self, vdsd: Any, incoming: dict[str, Any]) -> None:
         """Apply writable properties to a vdSD.
 
         Supports wildcard expansion per §7.1.2: if a container property
@@ -1414,6 +1430,15 @@ class VdcHost:
                                 vdsd.dsuid,
                                 idx,
                             )
+                            if btn.on_settings_changed is not None:
+                                try:
+                                    await btn.on_settings_changed(btn, settings)
+                                except Exception:
+                                    logger.exception(
+                                        "on_settings_changed callback raised for buttonInput[%d] on vdSD '%s'",
+                                        idx,
+                                        vdsd.dsuid,
+                                    )
         # Binary input settings (§4.3.2).
         if "binaryInputSettings" in incoming:
             bi_settings = incoming["binaryInputSettings"]
@@ -1433,6 +1458,15 @@ class VdcHost:
                                 vdsd.dsuid,
                                 idx,
                             )
+                            if bi.on_settings_changed is not None:
+                                try:
+                                    await bi.on_settings_changed(bi, settings)
+                                except Exception:
+                                    logger.exception(
+                                        "on_settings_changed callback raised for binaryInput[%d] on vdSD '%s'",
+                                        idx,
+                                        vdsd.dsuid,
+                                    )
         # Sensor input settings (§4.3.2).
         if "sensorSettings" in incoming:
             si_settings = incoming["sensorSettings"]
@@ -1452,6 +1486,15 @@ class VdcHost:
                                 vdsd.dsuid,
                                 idx,
                             )
+                            if si.on_settings_changed is not None:
+                                try:
+                                    await si.on_settings_changed(si, settings)
+                                except Exception:
+                                    logger.exception(
+                                        "on_settings_changed callback raised for sensorInput[%d] on vdSD '%s'",
+                                        idx,
+                                        vdsd.dsuid,
+                                    )
         # Output settings (§4.8.2).
         if "outputSettings" in incoming:
             out_settings = incoming["outputSettings"]
@@ -1463,6 +1506,14 @@ class VdcHost:
                         "vdSD '%s' outputSettings updated",
                         vdsd.dsuid,
                     )
+                    if output.on_settings_changed is not None:
+                        try:
+                            await output.on_settings_changed(output, out_settings)
+                        except Exception:
+                            logger.exception(
+                                "on_settings_changed callback raised for output on vdSD '%s'",
+                                vdsd.dsuid,
+                            )
         # Output state (§4.8.3) — only localPriority is writable.
         if "outputState" in incoming:
             out_state = incoming["outputState"]
@@ -1813,7 +1864,7 @@ class VdcHost:
                             vdc.dsuid,
                         )
 
-            asyncio.ensure_future(_do_scan(vdcs_to_scan, session, dsuid_str))
+            asyncio.create_task(_do_scan(vdcs_to_scan, session, dsuid_str))
             resp.generic_response.code = pb.ERR_OK
             return resp
 

--- a/src/pydsvdcapi/vdc_host.py
+++ b/src/pydsvdcapi/vdc_host.py
@@ -1393,7 +1393,9 @@ class VdcHost:
             vdc.zone_id = int(incoming["zoneID"])
             logger.info("vDC '%s' zoneID set to %d", vdc.dsuid, vdc.zone_id)
 
-    async def _apply_vdsd_set_property(self, vdsd: Any, incoming: dict[str, Any]) -> None:
+    async def _apply_vdsd_set_property(
+        self, vdsd: Any, incoming: dict[str, Any]
+    ) -> None:
         """Apply writable properties to a vdSD.
 
         Supports wildcard expansion per §7.1.2: if a container property

--- a/tests/test_actions.py
+++ b/tests/test_actions.py
@@ -1370,7 +1370,7 @@ class TestGenericRequestSetConfiguration:
 class TestSetPropertyCustomActions:
     """Tests for setProperty writes to customActions."""
 
-    def test_apply_custom_action_settings(self):
+    async def test_apply_custom_action_settings(self):
         host, _, _, vdsd = _make_stack()
         cust = CustomAction(
             vdsd=vdsd,
@@ -1386,11 +1386,11 @@ class TestSetPropertyCustomActions:
                 "0": {"title": "New Title", "params": {"vol": 99}},
             }
         }
-        host._apply_vdsd_set_property(vdsd, incoming)
+        await host._apply_vdsd_set_property(vdsd, incoming)
         assert cust.title == "New Title"
         assert cust.params == {"vol": 99}
 
-    def test_apply_custom_action_nonexistent_index_ignored(self):
+    async def test_apply_custom_action_nonexistent_index_ignored(self):
         host, _, _, vdsd = _make_stack()
         cust = CustomAction(
             vdsd=vdsd,
@@ -1407,5 +1407,5 @@ class TestSetPropertyCustomActions:
             }
         }
         # Should not raise.
-        host._apply_vdsd_set_property(vdsd, incoming)
+        await host._apply_vdsd_set_property(vdsd, incoming)
         assert cust.title == "Title"  # unchanged

--- a/tests/test_binary_input.py
+++ b/tests/test_binary_input.py
@@ -1047,7 +1047,7 @@ class TestVdcHostBinaryInputSetProperty:
         vdc.add_device(device)
         return host, vdc, device, vdsd, bi
 
-    def test_set_binary_input_settings(self):
+    async def test_set_binary_input_settings(self):
         host, vdc, device, vdsd, bi = self._setup()
 
         incoming = {
@@ -1059,12 +1059,12 @@ class TestVdcHostBinaryInputSetProperty:
             },
         }
 
-        host._apply_vdsd_set_property(vdsd, incoming)
+        await host._apply_vdsd_set_property(vdsd, incoming)
 
         assert bi.group == 5
         assert bi.sensor_function == BinaryInputType.SMOKE
 
-    def test_set_binary_input_settings_partial(self):
+    async def test_set_binary_input_settings_partial(self):
         host, vdc, device, vdsd, bi = self._setup()
 
         incoming = {
@@ -1073,12 +1073,12 @@ class TestVdcHostBinaryInputSetProperty:
             },
         }
 
-        host._apply_vdsd_set_property(vdsd, incoming)
+        await host._apply_vdsd_set_property(vdsd, incoming)
 
         assert bi.group == 8
         assert bi.sensor_function == BinaryInputType.PRESENCE  # unchanged
 
-    def test_set_binary_input_unknown_index(self):
+    async def test_set_binary_input_unknown_index(self):
         host, vdc, device, vdsd, bi = self._setup()
 
         incoming = {
@@ -1088,10 +1088,10 @@ class TestVdcHostBinaryInputSetProperty:
         }
 
         # Should not raise.
-        host._apply_vdsd_set_property(vdsd, incoming)
+        await host._apply_vdsd_set_property(vdsd, incoming)
         assert bi.group == 0  # unchanged
 
-    def test_set_property_via_message(self):
+    async def test_set_property_via_message(self):
         """Full message dispatch for setProperty binaryInputSettings."""
         host, vdc, device, vdsd, bi = self._setup()
 
@@ -1109,7 +1109,7 @@ class TestVdcHostBinaryInputSetProperty:
         group_elem.name = "group"
         group_elem.value.v_uint64 = 6
 
-        resp = host._handle_set_property(msg)
+        resp = await host._handle_set_property(msg)
 
         assert resp.generic_response.code == pb.ERR_OK
         assert bi.group == 6

--- a/tests/test_button_input.py
+++ b/tests/test_button_input.py
@@ -900,7 +900,7 @@ class TestButtonInputSessionManagement:
 class TestVdcHostButtonInputSetProperty:
     """buttonInputSettings via _apply_vdsd_set_property."""
 
-    def test_set_button_settings(self):
+    async def test_set_button_settings(self):
         host, vdc, device, vdsd = _scaffold()
         host.add_vdc(vdc)
         vdc.add_device(device)
@@ -919,7 +919,7 @@ class TestVdcHostButtonInputSetProperty:
                 },
             },
         }
-        host._apply_vdsd_set_property(vdsd, incoming)
+        await host._apply_vdsd_set_property(vdsd, incoming)
 
         assert btn.group == 3
         assert btn.function == ButtonFunction.AREA_1

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -1252,12 +1252,12 @@ class TestOutputSessionManagement:
 class TestVdcHostOutputSetProperty:
     """Test VdcHost._apply_vdsd_set_property for outputSettings/outputState."""
 
-    def test_apply_output_settings(self):
+    async def test_apply_output_settings(self):
         host, vdc, device, vdsd = _make_stack()
         out = _make_output(vdsd)
         vdsd.set_output(out)
 
-        host._apply_vdsd_set_property(
+        await host._apply_vdsd_set_property(
             vdsd,
             {
                 "outputSettings": {"mode": 2, "pushChanges": True},
@@ -1267,12 +1267,12 @@ class TestVdcHostOutputSetProperty:
         assert out.mode == OutputMode.GRADUAL
         assert out.push_changes is True
 
-    def test_apply_output_state(self):
+    async def test_apply_output_state(self):
         host, vdc, device, vdsd = _make_stack()
         out = _make_output(vdsd)
         vdsd.set_output(out)
 
-        host._apply_vdsd_set_property(
+        await host._apply_vdsd_set_property(
             vdsd,
             {
                 "outputState": {"localPriority": True},
@@ -1281,34 +1281,34 @@ class TestVdcHostOutputSetProperty:
 
         assert out.local_priority is True
 
-    def test_apply_output_settings_no_output(self):
+    async def test_apply_output_settings_no_output(self):
         """Settings for non-existing output should not crash."""
         host, vdc, device, vdsd = _make_stack()
-        host._apply_vdsd_set_property(
+        await host._apply_vdsd_set_property(
             vdsd,
             {
                 "outputSettings": {"mode": 1},
             },
         )
 
-    def test_apply_output_state_no_output(self):
+    async def test_apply_output_state_no_output(self):
         """State for non-existing output should not crash."""
         host, vdc, device, vdsd = _make_stack()
-        host._apply_vdsd_set_property(
+        await host._apply_vdsd_set_property(
             vdsd,
             {
                 "outputState": {"localPriority": True},
             },
         )
 
-    def test_apply_output_settings_not_dict(self):
+    async def test_apply_output_settings_not_dict(self):
         """Non-dict outputSettings should be silently ignored."""
         host, vdc, device, vdsd = _make_stack()
         out = _make_output(
             vdsd
         )  # DIMMER → auto-derives GRADUAL; invalid settings leave it unchanged
         vdsd.set_output(out)
-        host._apply_vdsd_set_property(
+        await host._apply_vdsd_set_property(
             vdsd,
             {
                 "outputSettings": "invalid",
@@ -1316,12 +1316,12 @@ class TestVdcHostOutputSetProperty:
         )
         assert out.mode == OutputMode.GRADUAL
 
-    def test_apply_output_state_not_dict(self):
+    async def test_apply_output_state_not_dict(self):
         """Non-dict outputState should be silently ignored."""
         host, vdc, device, vdsd = _make_stack()
         out = _make_output(vdsd)
         vdsd.set_output(out)
-        host._apply_vdsd_set_property(
+        await host._apply_vdsd_set_property(
             vdsd,
             {
                 "outputState": "invalid",
@@ -1329,13 +1329,13 @@ class TestVdcHostOutputSetProperty:
         )
         assert out.local_priority is False
 
-    def test_mixed_set_property(self):
+    async def test_mixed_set_property(self):
         """Verify output + other settings applied together."""
         host, vdc, device, vdsd = _make_stack()
         out = _make_output(vdsd)
         vdsd.set_output(out)
 
-        host._apply_vdsd_set_property(
+        await host._apply_vdsd_set_property(
             vdsd,
             {
                 "name": "Renamed",
@@ -2193,7 +2193,7 @@ class TestVdcHostSceneDispatch:
         for elem in dict_to_elements(scene_data):
             msg.vdsm_request_set_property.properties.append(elem)
 
-        resp = host._handle_set_property(msg)
+        resp = await host._handle_set_property(msg)
         assert resp.generic_response.code == pb.ERR_OK
 
         entry = out.get_scene(5)

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -524,10 +524,7 @@ class TestOutputSettingsProperties:
         assert settings["mode"] == int(OutputMode.GRADUAL)
         assert settings["activeGroup"] == 1
         assert settings["pushChanges"] is False
-        # groups now always has 64 entries (all IDs 0-63); only group 1 is True
-        assert settings["groups"]["1"] is True
-        assert len(settings["groups"]) == 64
-        assert all(v is False for k, v in settings["groups"].items() if k != "1")
+        assert settings["groups"] == {"1": True}
         assert "onThreshold" not in settings
         assert "minBrightness" not in settings
 
@@ -537,16 +534,7 @@ class TestOutputSettingsProperties:
         settings = out.get_settings_properties()
 
         assert "groups" in settings
-        # groups always has 64 entries; groups 1, 3, 5 are True
-        assert settings["groups"]["1"] is True
-        assert settings["groups"]["3"] is True
-        assert settings["groups"]["5"] is True
-        assert len(settings["groups"]) == 64
-        assert all(
-            v is False
-            for k, v in settings["groups"].items()
-            if k not in ("1", "3", "5")
-        )
+        assert settings["groups"] == {"1": True, "3": True, "5": True}
 
     def test_with_all_optional_fields(self):
         # vdsd is YELLOW (primaryGroup=1) — light-specific settings are emitted
@@ -1491,12 +1479,11 @@ class TestOutputExport:
 class TestOutputEdgeCases:
     """Edge cases and boundary conditions."""
 
-    def test_empty_groups_all_false(self):
+    def test_empty_groups_returns_empty_dict(self):
         host, vdc, device, vdsd = _make_stack()
         out = _make_output(vdsd, groups=set())
         settings = out.get_settings_properties()
-        assert len(settings["groups"]) == 64
-        assert all(v is False for v in settings["groups"].values())
+        assert settings["groups"] == {}
 
     def test_empty_groups_not_in_tree(self):
         host, vdc, device, vdsd = _make_stack()
@@ -1514,12 +1501,8 @@ class TestOutputEdgeCases:
         host, vdc, device, vdsd = _make_stack()
         out = _make_output(vdsd, groups={10, 3, 7, 1})
         settings = out.get_settings_properties()
-        # groups always has 64 entries (0-63); keys are numeric-string sorted
-        assert settings["groups"]["1"] is True
-        assert settings["groups"]["3"] is True
-        assert settings["groups"]["7"] is True
-        assert settings["groups"]["10"] is True
-        assert len(settings["groups"]) == 64
+        keys = list(settings["groups"].keys())
+        assert keys == ["1", "3", "7", "10"]
 
     def test_on_off_output(self):
         """Basic on/off output (relay, socket)."""

--- a/tests/test_output_channel.py
+++ b/tests/test_output_channel.py
@@ -265,6 +265,85 @@ class TestOutputChannelConstruction:
         assert ch.max_value == 100.0
         assert ch.resolution == 1.0
 
+    def test_custom_channel_siunit_symbol_enum_values(self):
+        _, _, _, vdsd = _make_stack()
+        out = _make_output(vdsd)
+        ch = OutputChannel(
+            output=out,
+            channel_type=240,  # Custom/proprietary type
+            ds_index=0,
+            name="operatingMode",
+            min_value=0,
+            max_value=3,
+            resolution=1,
+            siunit="",
+            symbol="",
+            enum_values={0: "off", 1: "heating", 2: "cooling", 3: "auto"},
+        )
+        desc = ch.get_description_properties()
+        assert desc["name"] == "operatingMode"
+        assert desc["min"] == 0
+        assert desc["max"] == 3
+        assert "siunit" not in desc  # empty string → omitted
+        assert "symbol" not in desc
+        assert desc["values"] == {
+            "0": "off",
+            "1": "heating",
+            "2": "cooling",
+            "3": "auto",
+        }
+
+    def test_custom_channel_siunit_symbol_in_description(self):
+        _, _, _, vdsd = _make_stack()
+        out = _make_output(vdsd)
+        ch = OutputChannel(
+            output=out,
+            channel_type=241,
+            ds_index=0,
+            name="powerLevel",
+            min_value=0,
+            max_value=5000,
+            resolution=1,
+            siunit="watt",
+            symbol="W",
+        )
+        desc = ch.get_description_properties()
+        assert desc["siunit"] == "watt"
+        assert desc["symbol"] == "W"
+        assert "values" not in desc  # no enum_values given
+
+    def test_predefined_channel_ignores_siunit_symbol_enum_values_params(self):
+        # Predefined channel: spec is authoritative; caller params for
+        # siunit/symbol/enum_values must be silently ignored.
+        _, _, _, vdsd = _make_stack()
+        out = _make_output(vdsd)
+        ch = OutputChannel(
+            output=out,
+            channel_type=OutputChannelType.BRIGHTNESS,
+            ds_index=0,
+            siunit="kelvin",  # must be ignored
+            symbol="K",  # must be ignored
+            enum_values={0: "x"},  # must be ignored
+        )
+        desc = ch.get_description_properties()
+        assert desc["siunit"] == "percent"  # from spec
+        assert desc["symbol"] == "%"  # from spec
+        assert "values" not in desc  # spec has no enum_values
+
+    def test_predefined_enum_channel_ignores_enum_values_param(self):
+        # FCU_OPERATION_MODE is a predefined enum channel.
+        _, _, _, vdsd = _make_stack()
+        out = _make_output(vdsd)
+        ch = OutputChannel(
+            output=out,
+            channel_type=OutputChannelType.FCU_OPERATION_MODE,
+            ds_index=0,
+            enum_values={0: "wrong"},  # must be ignored
+        )
+        desc = ch.get_description_properties()
+        assert desc["values"]["0"] == "off"  # from spec, not "wrong"
+        assert desc["values"]["1"] == "heating"
+
     def test_repr(self):
         _, _, _, vdsd = _make_stack()
         out = _make_output(vdsd)
@@ -860,6 +939,75 @@ class TestChannelPersistence:
         assert tree["min"] == 0
         assert tree["max"] == 100
         assert "resolution" in tree
+        # Predefined channel: siunit/symbol are stored (from spec).
+        assert tree["siunit"] == "percent"
+        assert tree["symbol"] == "%"
+        assert "enumValues" not in tree  # brightness has no discrete values
+
+    def test_custom_channel_property_tree_persists_siunit_symbol_enum_values(self):
+        _, _, _, vdsd = _make_stack()
+        out = _make_output(vdsd)
+        ch = OutputChannel(
+            output=out,
+            channel_type=240,
+            ds_index=0,
+            name="myMode",
+            min_value=0,
+            max_value=3,
+            resolution=1,
+            siunit="",
+            symbol="",
+            enum_values={0: "off", 1: "on", 2: "eco"},
+        )
+        tree = ch.get_property_tree()
+        assert "siunit" not in tree  # empty string → not persisted
+        assert "symbol" not in tree
+        assert tree["enumValues"] == {"0": "off", "1": "on", "2": "eco"}
+
+    def test_custom_channel_siunit_symbol_persisted_and_restored(self):
+        _, _, _, vdsd = _make_stack()
+        out = _make_output(vdsd)
+        ch1 = OutputChannel(
+            output=out,
+            channel_type=241,
+            ds_index=0,
+            name="powerWatts",
+            min_value=0,
+            max_value=5000,
+            resolution=1,
+            siunit="watt",
+            symbol="W",
+        )
+        tree = ch1.get_property_tree()
+        assert tree["siunit"] == "watt"
+        assert tree["symbol"] == "W"
+
+        # Restore into a new instance and verify description.
+        ch2 = OutputChannel(output=out, channel_type=241, ds_index=0)
+        ch2._apply_state(tree)
+        desc = ch2.get_description_properties()
+        assert desc["siunit"] == "watt"
+        assert desc["symbol"] == "W"
+
+    def test_custom_channel_enum_values_round_trip(self):
+        _, _, _, vdsd = _make_stack()
+        out = _make_output(vdsd)
+        ch1 = OutputChannel(
+            output=out,
+            channel_type=242,
+            ds_index=0,
+            name="operMode",
+            min_value=0,
+            max_value=2,
+            resolution=1,
+            enum_values={0: "off", 1: "heat", 2: "cool"},
+        )
+        tree = ch1.get_property_tree()
+
+        ch2 = OutputChannel(output=out, channel_type=242, ds_index=0)
+        ch2._apply_state(tree)
+        desc = ch2.get_description_properties()
+        assert desc["values"] == {"0": "off", "1": "heat", "2": "cool"}
 
     def test_channel_apply_state(self):
         _, _, _, vdsd = _make_stack()

--- a/tests/test_property_handling.py
+++ b/tests/test_property_handling.py
@@ -440,7 +440,7 @@ class TestVdcHostPropertyDispatch:
         assert resp.type == pb.GENERIC_RESPONSE
         assert resp.generic_response.code == pb.ERR_NOT_FOUND
 
-    def test_set_property_host_name(self):
+    async def test_set_property_host_name(self):
         host = self._make_host()
         req = pb.Message()
         req.type = pb.VDSM_REQUEST_SET_PROPERTY
@@ -450,11 +450,11 @@ class TestVdcHostPropertyDispatch:
         p.name = "name"
         p.value.v_string = "New Host Name"
 
-        resp = host._handle_set_property(req)
+        resp = await host._handle_set_property(req)
         assert resp.generic_response.code == pb.ERR_OK
         assert host.name == "New Host Name"
 
-    def test_set_property_vdc_zone_id(self):
+    async def test_set_property_vdc_zone_id(self):
         from pydsvdcapi.vdc import Vdc
 
         host = self._make_host()
@@ -475,11 +475,11 @@ class TestVdcHostPropertyDispatch:
         p.name = "zoneID"
         p.value.v_int64 = 55
 
-        resp = host._handle_set_property(req)
+        resp = await host._handle_set_property(req)
         assert resp.generic_response.code == pb.ERR_OK
         assert vdc.zone_id == 55
 
-    def test_set_property_unknown_dsuid(self):
+    async def test_set_property_unknown_dsuid(self):
         host = self._make_host()
         req = pb.Message()
         req.type = pb.VDSM_REQUEST_SET_PROPERTY
@@ -489,7 +489,7 @@ class TestVdcHostPropertyDispatch:
         p.name = "name"
         p.value.v_string = "whatever"
 
-        resp = host._handle_set_property(req)
+        resp = await host._handle_set_property(req)
         assert resp.generic_response.code == pb.ERR_NOT_FOUND
 
     async def test_dispatch_routes_get_property(self):

--- a/tests/test_sensor_input.py
+++ b/tests/test_sensor_input.py
@@ -1123,7 +1123,7 @@ class TestVdcHostSensorInputSetProperty:
         vdc.add_device(device)
         return host, vdc, device, vdsd, si
 
-    def test_set_sensor_settings(self):
+    async def test_set_sensor_settings(self):
         host, vdc, device, vdsd, si = self._setup()
 
         incoming = {
@@ -1136,13 +1136,13 @@ class TestVdcHostSensorInputSetProperty:
             },
         }
 
-        host._apply_vdsd_set_property(vdsd, incoming)
+        await host._apply_vdsd_set_property(vdsd, incoming)
 
         assert si.group == 5
         assert si.min_push_interval == 10.0
         assert si.changes_only_interval == 30.0
 
-    def test_set_sensor_settings_partial(self):
+    async def test_set_sensor_settings_partial(self):
         host, vdc, device, vdsd, si = self._setup()
 
         incoming = {
@@ -1151,12 +1151,12 @@ class TestVdcHostSensorInputSetProperty:
             },
         }
 
-        host._apply_vdsd_set_property(vdsd, incoming)
+        await host._apply_vdsd_set_property(vdsd, incoming)
 
         assert si.group == 8
         assert si.min_push_interval == 2.0  # unchanged default
 
-    def test_set_sensor_settings_unknown_index(self):
+    async def test_set_sensor_settings_unknown_index(self):
         host, vdc, device, vdsd, si = self._setup()
 
         incoming = {
@@ -1166,10 +1166,10 @@ class TestVdcHostSensorInputSetProperty:
         }
 
         # Should not raise.
-        host._apply_vdsd_set_property(vdsd, incoming)
+        await host._apply_vdsd_set_property(vdsd, incoming)
         assert si.group == 0  # unchanged
 
-    def test_set_property_via_message(self):
+    async def test_set_property_via_message(self):
         """Full message dispatch for setProperty sensorSettings."""
         host, vdc, device, vdsd, si = self._setup()
 
@@ -1187,7 +1187,7 @@ class TestVdcHostSensorInputSetProperty:
         group_elem.name = "group"
         group_elem.value.v_uint64 = 6
 
-        resp = host._handle_set_property(msg)
+        resp = await host._handle_set_property(msg)
 
         assert resp.generic_response.code == pb.ERR_OK
         assert si.group == 6

--- a/tests/test_settings_callbacks.py
+++ b/tests/test_settings_callbacks.py
@@ -1,0 +1,377 @@
+"""Tests for on_settings_changed callbacks and push_settings() methods."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pydsvdcapi as api
+from pydsvdcapi.binary_input import BinaryInput
+from pydsvdcapi.button_input import ButtonInput
+from pydsvdcapi.dsuid import DsUid, DsUidNamespace
+from pydsvdcapi.enums import (
+    BinaryInputType,
+    BinaryInputUsage,
+    ButtonElementID,
+    ButtonType,
+    ColorGroup,
+    SensorType,
+    SensorUsage,
+    OutputFunction,
+    OutputUsage,
+)
+from pydsvdcapi.output import Output
+from pydsvdcapi.property_handling import elements_to_dict
+from pydsvdcapi.sensor_input import SensorInput
+from pydsvdcapi.session import VdcSession
+from pydsvdcapi.vdc import Vdc
+from pydsvdcapi.vdc_host import VdcHost
+from pydsvdcapi.vdsd import Device, Vdsd
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_host(**kwargs: Any) -> VdcHost:
+    kw: dict[str, Any] = {"name": "Test Host", "mac": "AA:BB:CC:DD:EE:FF"}
+    kw.update(kwargs)
+    host = VdcHost(**kw)
+    host._cancel_auto_save()
+    return host
+
+
+def _make_vdc(host: VdcHost, **kwargs: Any) -> Vdc:
+    defaults: dict[str, Any] = {
+        "host": host,
+        "implementation_id": "x-test-cb",
+        "name": "Test CB vDC",
+        "model": "Test CB v1",
+    }
+    defaults.update(kwargs)
+    return Vdc(**defaults)
+
+
+def _base_dsuid(name: str = "cb-test-device") -> DsUid:
+    return DsUid.from_name_in_space(name, DsUidNamespace.VDC)
+
+
+def _make_device(vdc: Vdc, name: str = "cb-test-device") -> Device:
+    return Device(vdc=vdc, dsuid=_base_dsuid(name))
+
+
+def _make_vdsd(device: Device, **kwargs: Any) -> Vdsd:
+    defaults: dict[str, Any] = {
+        "device": device,
+        "primary_group": ColorGroup.BLACK,
+        "name": "CB Test vdSD",
+        "model": "Test CB vdSD",
+    }
+    defaults.update(kwargs)
+    return Vdsd(**defaults)
+
+
+def _make_mock_session() -> MagicMock:
+    session = MagicMock(spec=VdcSession)
+    session.is_active = True
+    session.send_notification = AsyncMock()
+    return session
+
+
+def _make_binary_input(vdsd: Vdsd, **kwargs: Any) -> BinaryInput:
+    defaults: dict[str, Any] = {
+        "vdsd": vdsd,
+        "ds_index": 0,
+        "sensor_function": BinaryInputType.PRESENCE,
+        "input_usage": BinaryInputUsage.ROOM_CLIMATE,
+        "name": "Test PIR",
+    }
+    defaults.update(kwargs)
+    return BinaryInput(**defaults)
+
+
+def _make_button_input(vdsd: Vdsd, **kwargs: Any) -> ButtonInput:
+    defaults: dict[str, Any] = {
+        "vdsd": vdsd,
+        "ds_index": 0,
+        "button_type": ButtonType.SINGLE_PUSHBUTTON,
+        "button_element_id": ButtonElementID.CENTER,
+        "button_id": 0,
+        "name": "Test Button",
+    }
+    defaults.update(kwargs)
+    return ButtonInput(**defaults)
+
+
+def _make_sensor_input(vdsd: Vdsd, **kwargs: Any) -> SensorInput:
+    defaults: dict[str, Any] = {
+        "vdsd": vdsd,
+        "ds_index": 0,
+        "sensor_type": SensorType.TEMPERATURE,
+        "sensor_usage": SensorUsage.ROOM,
+        "name": "Room Temperature",
+        "min_value": -20.0,
+        "max_value": 60.0,
+        "resolution": 0.1,
+    }
+    defaults.update(kwargs)
+    return SensorInput(**defaults)
+
+
+def _make_output(vdsd: Vdsd, **kwargs: Any) -> Output:
+    defaults: dict[str, Any] = {
+        "vdsd": vdsd,
+        "function": OutputFunction.DIMMER,
+        "output_usage": OutputUsage.ROOM,
+        "name": "Test Dimmer",
+        "default_group": 1,
+        "active_group": 1,
+        "groups": {1},
+    }
+    defaults.update(kwargs)
+    return Output(**defaults)
+
+
+def _scaffold() -> tuple[VdcHost, Vdc, Device, Vdsd]:
+    host = _make_host()
+    vdc = _make_vdc(host)
+    device = _make_device(vdc)
+    vdsd = _make_vdsd(device)
+    device.add_vdsd(vdsd)
+    vdc.add_device(device)
+    host.add_vdc(vdc)
+    return host, vdc, device, vdsd
+
+
+# ===========================================================================
+# BinaryInput
+# ===========================================================================
+
+
+class TestBinaryInputCallback:
+    """Tests for BinaryInput.on_settings_changed callback."""
+
+    def test_binary_input_callback_default_is_none(self):
+        _, _, _, vdsd = _scaffold()
+        bi = _make_binary_input(vdsd)
+        assert bi.on_settings_changed is None
+
+    def test_binary_input_callback_settable_and_clearable(self):
+        _, _, _, vdsd = _scaffold()
+        bi = _make_binary_input(vdsd)
+
+        async def cb(b, settings):
+            pass
+
+        bi.on_settings_changed = cb
+        assert bi.on_settings_changed is cb
+
+        bi.on_settings_changed = None
+        assert bi.on_settings_changed is None
+
+    async def test_binary_input_callback_receives_correct_args(self):
+        _, _, _, vdsd = _scaffold()
+        bi = _make_binary_input(vdsd)
+
+        received: list[Any] = []
+
+        async def cb(component, settings):
+            received.append((component, settings))
+
+        bi.on_settings_changed = cb
+        await bi.on_settings_changed(bi, {"group": 5})
+
+        assert len(received) == 1
+        assert received[0][0] is bi
+        assert received[0][1] == {"group": 5}
+
+    async def test_binary_input_push_settings_no_session(self):
+        _, _, _, vdsd = _scaffold()
+        bi = _make_binary_input(vdsd)
+        bi._session = None
+        # Must not raise
+        await bi.push_settings()
+
+    async def test_binary_input_push_settings_not_announced(self):
+        _, _, _, vdsd = _scaffold()
+        bi = _make_binary_input(vdsd)
+        vdsd.add_binary_input(bi)
+
+        session = _make_mock_session()
+        bi._session = session
+        vdsd._announced = False
+
+        await bi.push_settings()
+        session.send_notification.assert_not_called()
+
+    async def test_binary_input_push_settings_sends_notification(self):
+        _, _, _, vdsd = _scaffold()
+        bi = _make_binary_input(vdsd, ds_index=2, group=3,
+                                sensor_function=BinaryInputType.SMOKE)
+        vdsd.add_binary_input(bi)
+
+        session = _make_mock_session()
+        bi._session = session
+        vdsd._announced = True
+
+        await bi.push_settings()
+
+        session.send_notification.assert_called_once()
+        msg = session.send_notification.call_args[0][0]
+        props = elements_to_dict(msg.vdc_send_push_notification.changedproperties)
+
+        assert "binaryInputSettings" in props
+        inner = props["binaryInputSettings"][str(bi.ds_index)]
+        assert "group" in inner
+        assert "sensorFunction" in inner
+
+
+# ===========================================================================
+# ButtonInput
+# ===========================================================================
+
+
+class TestButtonInputCallback:
+    """Tests for ButtonInput.on_settings_changed callback and push_settings."""
+
+    def test_button_input_callback_default_is_none(self):
+        _, _, _, vdsd = _scaffold()
+        btn = _make_button_input(vdsd)
+        assert btn.on_settings_changed is None
+
+    async def test_button_input_push_settings_no_session(self):
+        _, _, _, vdsd = _scaffold()
+        btn = _make_button_input(vdsd)
+        btn._session = None
+        # Must not raise
+        await btn.push_settings()
+
+    async def test_button_input_push_settings_sends_notification(self):
+        _, _, _, vdsd = _scaffold()
+        btn = _make_button_input(vdsd, ds_index=1)
+        vdsd.add_button_input(btn)
+
+        session = _make_mock_session()
+        btn._session = session
+        vdsd._announced = True
+
+        await btn.push_settings()
+
+        session.send_notification.assert_called_once()
+        msg = session.send_notification.call_args[0][0]
+        props = elements_to_dict(msg.vdc_send_push_notification.changedproperties)
+
+        assert "buttonInputSettings" in props
+        inner = props["buttonInputSettings"][str(btn.ds_index)]
+        assert "group" in inner
+        assert "function" in inner
+        assert "mode" in inner
+
+
+# ===========================================================================
+# SensorInput
+# ===========================================================================
+
+
+class TestSensorInputCallback:
+    """Tests for SensorInput.on_settings_changed callback and push_settings."""
+
+    def test_sensor_input_callback_default_is_none(self):
+        _, _, _, vdsd = _scaffold()
+        si = _make_sensor_input(vdsd)
+        assert si.on_settings_changed is None
+
+    async def test_sensor_input_push_settings_no_session(self):
+        _, _, _, vdsd = _scaffold()
+        si = _make_sensor_input(vdsd)
+        si._session = None
+        # Must not raise
+        await si.push_settings()
+
+    async def test_sensor_input_push_settings_sends_notification(self):
+        _, _, _, vdsd = _scaffold()
+        si = _make_sensor_input(vdsd, ds_index=0)
+        vdsd.add_sensor_input(si)
+
+        session = _make_mock_session()
+        si._session = session
+        vdsd._announced = True
+
+        await si.push_settings()
+
+        session.send_notification.assert_called_once()
+        msg = session.send_notification.call_args[0][0]
+        props = elements_to_dict(msg.vdc_send_push_notification.changedproperties)
+
+        assert "sensorSettings" in props
+        inner = props["sensorSettings"][str(si.ds_index)]
+        assert "group" in inner
+        assert "minPushInterval" in inner
+        assert "changesOnlyInterval" in inner
+
+
+# ===========================================================================
+# Output
+# ===========================================================================
+
+
+class TestOutputCallback:
+    """Tests for Output.on_settings_changed callback and push_settings."""
+
+    def test_output_callback_default_is_none(self):
+        _, _, _, vdsd = _scaffold()
+        out = _make_output(vdsd)
+        assert out.on_settings_changed is None
+
+    async def test_output_push_settings_no_session(self):
+        _, _, _, vdsd = _scaffold()
+        out = _make_output(vdsd)
+        out._session = None
+        # Must not raise
+        await out.push_settings()
+
+    async def test_output_push_settings_not_announced(self):
+        _, _, _, vdsd = _scaffold()
+        out = _make_output(vdsd)
+        vdsd.set_output(out)
+
+        session = _make_mock_session()
+        out.start_session(session)
+        vdsd._announced = False
+
+        await out.push_settings()
+        session.send_notification.assert_not_called()
+
+    async def test_output_push_settings_sends_notification(self):
+        _, _, _, vdsd = _scaffold()
+        out = _make_output(vdsd)
+        vdsd.set_output(out)
+
+        session = _make_mock_session()
+        out.start_session(session)
+        vdsd._announced = True
+
+        await out.push_settings()
+
+        session.send_notification.assert_called_once()
+        msg = session.send_notification.call_args[0][0]
+        props = elements_to_dict(msg.vdc_send_push_notification.changedproperties)
+
+        assert "outputSettings" in props
+        inner = props["outputSettings"]
+        assert "mode" in inner
+
+
+# ===========================================================================
+# Exports
+# ===========================================================================
+
+
+class TestCallbackTypeExports:
+    """Verify all four callback types are exported from pydsvdcapi."""
+
+    def test_callback_types_exported(self):
+        assert hasattr(api, "BinaryInputSettingsChangedCallback")
+        assert hasattr(api, "ButtonInputSettingsChangedCallback")
+        assert hasattr(api, "SensorInputSettingsChangedCallback")
+        assert hasattr(api, "OutputSettingsChangedCallback")

--- a/tests/test_settings_callbacks.py
+++ b/tests/test_settings_callbacks.py
@@ -15,10 +15,10 @@ from pydsvdcapi.enums import (
     ButtonElementID,
     ButtonType,
     ColorGroup,
-    SensorType,
-    SensorUsage,
     OutputFunction,
     OutputUsage,
+    SensorType,
+    SensorUsage,
 )
 from pydsvdcapi.output import Output
 from pydsvdcapi.property_handling import elements_to_dict

--- a/tests/test_settings_callbacks.py
+++ b/tests/test_settings_callbacks.py
@@ -206,8 +206,9 @@ class TestBinaryInputCallback:
 
     async def test_binary_input_push_settings_sends_notification(self):
         _, _, _, vdsd = _scaffold()
-        bi = _make_binary_input(vdsd, ds_index=2, group=3,
-                                sensor_function=BinaryInputType.SMOKE)
+        bi = _make_binary_input(
+            vdsd, ds_index=2, group=3, sensor_function=BinaryInputType.SMOKE
+        )
         vdsd.add_binary_input(bi)
 
         session = _make_mock_session()

--- a/tests/test_vdc_host.py
+++ b/tests/test_vdc_host.py
@@ -1218,7 +1218,7 @@ class TestSetPropertyChannelStatesNumericKey:
             return task
 
         with patch("pydsvdcapi.vdc_host.asyncio.create_task", side_effect=collect_task):
-            host._handle_set_property(msg)
+            await host._handle_set_property(msg)
 
         if tasks:
             await asyncio.gather(*tasks)

--- a/tests/test_vdsd.py
+++ b/tests/test_vdsd.py
@@ -1167,7 +1167,7 @@ class TestVdcHostVdsdPropertyDispatch:
         resp = host._handle_get_property(req)
         assert resp.type == pb.VDC_RESPONSE_GET_PROPERTY
 
-    def test_set_property_name_for_vdsd(self):
+    async def test_set_property_name_for_vdsd(self):
         host = _make_host()
         vdc = _make_vdc(host)
         host.add_vdc(vdc)
@@ -1188,11 +1188,11 @@ class TestVdcHostVdsdPropertyDispatch:
         elem.name = "name"
         elem.value.v_string = "New Name"
 
-        resp = host._handle_set_property(req)
+        resp = await host._handle_set_property(req)
         assert resp.generic_response.code == pb.ERR_OK
         assert vdsd.name == "New Name"
 
-    def test_set_property_zone_for_vdsd(self):
+    async def test_set_property_zone_for_vdsd(self):
         host = _make_host()
         vdc = _make_vdc(host)
         host.add_vdc(vdc)
@@ -1212,7 +1212,7 @@ class TestVdcHostVdsdPropertyDispatch:
         elem.name = "zoneID"
         elem.value.v_uint64 = 42
 
-        resp = host._handle_set_property(req)
+        resp = await host._handle_set_property(req)
         assert resp.generic_response.code == pb.ERR_OK
         assert vdsd.zone_id == 42
 
@@ -1380,7 +1380,7 @@ class TestW3OptionalProperties:
 
     # --- setProperty (r/w progMode via vdc_host) -----------------------
 
-    def test_set_property_prog_mode(self):
+    async def test_set_property_prog_mode(self):
         host = _make_host()
         vdc = _make_vdc(host)
         host.add_vdc(vdc)
@@ -1400,7 +1400,7 @@ class TestW3OptionalProperties:
         elem.name = "progMode"
         elem.value.v_bool = True
 
-        resp = host._handle_set_property(req)
+        resp = await host._handle_set_property(req)
         assert resp.generic_response.code == pb.ERR_OK
         assert vdsd.prog_mode is True
 


### PR DESCRIPTION
## Summary

This branch prepares release **v0.9.0**, incorporating several feature additions and protocol correctness fixes developed since v0.8.9:

- **Settings callbacks** (`on_settings_changed`) on `Output`, `BinaryInput`, `ButtonInput`, `SensorInput` — fires when the vdSM writes settings via `setProperty`, letting application code react to dSS-side configuration changes
- **`push_settings()` methods** on all four component types — sends `VDC_SEND_PUSH_NOTIFICATION` with the component's full settings subtree so device code can push settings changes to the vdSM
- **Custom channel parameters** (`siunit`, `symbol`, `enum_values`) on `OutputChannel` and `Output.add_channel()` — fully custom channel types can now carry all metadata; predefined types always use the spec values
- **Channel key backward compatibility** (`_ChannelCompatDict`) — `getProperty` requests for `channelDescriptions`, `channelSettings`, and `channelStates` now resolve numeric keys in addition to canonical name keys
- **`FCU_OPERATION_MODE`** channel type added to `OutputChannelType` and `CHANNEL_SPECS`
- **`modelFeatures`** emitted in canonical `ModelFeatureId` enum order
- **`outputSettings`** field gating corrected (shadow timing → group 2 only, light fields → group 1, climate fields → group 3)
- **`on_disconnect` callback** on `VdcHost.start()` — fires when the TCP connection is lost unexpectedly
- **`VdcHost` fixes**: port init sentinel, reannounce task cancellation, zeroconf resource safety, browser cleanup in `finally`
- **`movingState`** removed from `outputState` (not in spec)

## Test plan

- [ ] All 1556 tests pass (`pytest tests/ -q`)
- [ ] `ruff check src/` — no errors
- [ ] `mypy src/pydsvdcapi/` — no errors
- [ ] Verify `on_settings_changed` callback fires after dSS writes `outputSettings` / `binaryInputSettings` / `buttonInputSettings` / `sensorSettings`
- [ ] Verify `push_settings()` sends correct `VDC_SEND_PUSH_NOTIFICATION` wire format
- [ ] Verify custom channel type with `siunit`/`symbol`/`enum_values` appears correctly in `channelDescriptions`

🤖 Generated with [Claude Code](https://claude.com/claude-code)